### PR TITLE
feat: mention raid blocking

### DIFF
--- a/src/bot/commands/config/toggle/mentionRaiding.ts
+++ b/src/bot/commands/config/toggle/mentionRaiding.ts
@@ -1,0 +1,28 @@
+import { Command } from 'discord-akairo';
+import { Message, Permissions } from 'discord.js';
+import { MESSAGES, SETTINGS } from '../../../util/constants';
+
+export default class ToggleMentionRaidingCommand extends Command {
+	public constructor() {
+		super('config-toggle-mention-raiding', {
+			description: {
+				content: MESSAGES.COMMANDS.CONFIG.TOGGLE.MENTION_RAIDING.DESCRIPTION,
+			},
+			category: 'config',
+			channel: 'guild',
+			userPermissions: [Permissions.FLAGS.MANAGE_GUILD],
+			ratelimit: 2,
+		});
+	}
+
+	public async exec(message: Message): Promise<Message | Message[]> {
+		const mentionRaiding = this.client.settings.get(message.guild!, SETTINGS.MENTION_RAIDING);
+		if (mentionRaiding) {
+			this.client.settings.set(message.guild!, SETTINGS.MENTION_RAIDING, false);
+			return message.util!.reply(MESSAGES.COMMANDS.CONFIG.TOGGLE.MENTION_RAIDING.REPLY_DEACTIVATED);
+		}
+		this.client.settings.set(message.guild!, SETTINGS.MENTION_RAIDING, true);
+
+		return message.util!.reply(MESSAGES.COMMANDS.CONFIG.TOGGLE.MENTION_RAIDING.REPLY_ACTIVATED);
+	}
+}

--- a/src/bot/commands/config/toggle/toggle.ts
+++ b/src/bot/commands/config/toggle/toggle.ts
@@ -22,6 +22,7 @@ export default class ToggleCommand extends Command {
 				['config-toggle-moderation', 'mod', 'moderation'],
 				['config-toggle-role-state', 'role', 'rolestate', 'role-state'],
 				['config-toggle-token-filtering', 'tokenfilter', 'tokenfiltering', 'token'],
+				['config-toggle-mention-raiding', 'mentionraid', 'mentionraiding', 'mention'],
 			],
 			otherwise: (msg: Message) => {
 				const prefix = (this.handler.prefix as PrefixSupplier)(msg);

--- a/src/bot/listeners/client/mentionRaiding.ts
+++ b/src/bot/listeners/client/mentionRaiding.ts
@@ -1,0 +1,60 @@
+import { Listener } from 'discord-akairo';
+import { Message, Snowflake } from 'discord.js';
+import BanAction from '../../structures/case/actions/Ban';
+import { SETTINGS } from '../../util/constants';
+
+interface MentionData {
+	count: number;
+	timestamp: Date;
+}
+
+export default class MentionRaidingListener extends Listener {
+	private readonly recentMentions = new Map<Snowflake, MentionData[]>();
+
+	public constructor() {
+		super('mentionRaid', {
+			emitter: 'client',
+			event: 'message',
+			category: 'client',
+		});
+	}
+
+	public exec(message: Message): void {
+		const mentionCount = message.mentions.users.size;
+		if (mentionCount === 0 || message.member === null) return;
+
+		const member = message.member;
+		const mentionRaiding = this.client.settings.get(member.guild, SETTINGS.MENTION_RAIDING);
+		if (!mentionRaiding) return;
+
+		const id = member.id;
+		if (!this.recentMentions.has(id)) {
+			this.recentMentions.set(id, []);
+		}
+
+		let memberMentionData = this.recentMentions.get(id) || [];
+
+		memberMentionData = memberMentionData.filter(mentionData => Date.now() - mentionData.timestamp.getTime() < 6000);
+
+		memberMentionData.push({
+			count: mentionCount,
+			timestamp: message.createdAt,
+		});
+
+		this.recentMentions.set(id, memberMentionData);
+
+		const totalMentions = memberMentionData.map(mentionData => mentionData.count).reduce((a, b) => a + b);
+		if (totalMentions >= 50) {
+			const key = `${message.guild!.id}:${member.id}:BAN`;
+			message.guild!.caseQueue.add(async () =>
+				new BanAction({
+					message,
+					member,
+					keys: key,
+					reason: 'Raiding',
+					days: 1,
+				}).commit(),
+			);
+		}
+	}
+}

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -44,6 +44,7 @@ export enum SETTINGS {
 	GUILD_LOG = 'GUILD_LOG',
 	ROLE_STATE = 'ROLE_STATE',
 	TOKEN_FILTER = 'TOKEN_FILTER',
+	MENTION_RAIDING = 'MENTION_RAIDING',
 	DEFAULT_DOCS = 'DEFAULT_DOCS',
 	BLACKLIST = 'BLACKLIST',
 	MEMBER_LOG = 'MEMBER_LOG',
@@ -66,6 +67,7 @@ export interface Settings {
 	GUILD_LOG: string;
 	ROLE_STATE: boolean;
 	TOKEN_FILTER: boolean;
+	MENTION_RAIDING: boolean;
 	DEFAULT_DOCS: string;
 	BLACKLIST: string[];
 	MEMBER_LOG: {
@@ -132,6 +134,7 @@ export const MESSAGES = {
 				 • mod
 				 • rolestate
 				 • tokenfiltering
+				 • mentionraiding
 
 				Required: \`<>\` | Optional: \`[]\`
 			`,
@@ -313,6 +316,12 @@ export const MESSAGES = {
 					DESCRIPTION: 'Toggle token filtering feature on the server.',
 					REPLY_ACTIVATED: 'successfully activated token filtering!',
 					REPLY_DEACTIVATED: 'successfully deactivated token filtering!',
+				},
+
+				MENTION_RAIDING: {
+					DESCRIPTION: 'Toggle mention raid blocking on the server.',
+					REPLY_ACTIVATED: 'successfully activated mention raid blocking!',
+					REPLY_DEACTIVATED: 'successfully deactivated mention raid blocking!',
 				},
 			},
 		},


### PR DESCRIPTION
Automatically bans users who mentions 50 or more people in one minute.

This is a rebased version of #461 that should work with the new restructuring. Let me know if there is anything wrong because all I did was update the code but I wasn't able to test some parts of the bot because I couldn't figure out how to get the new tables with Hasura.