### PR TITLE
Add Discord data proxy for REST

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@
 node_modules
 **/node_modules
 
+# Build artifacts
+dist/
+typings/
+
 # Log files
 logs
 *.log

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -89,6 +89,14 @@ services:
       SHARD_STORE_TYPE: "redis"
       REDIS_URL: "redis://redis:6379"
 
+  proxy:
+    environment:
+      REDIS_URL: "redis://redis:6379/"
+      AMQP_URL: "amqp://rabbitmq/%2f"
+      AMQP_GROUP: "rest"
+      # AMQP_SUBGROUP: ""
+      AMQP_EVENT: "REQUEST"
+
   parser:
     environment:
       PGHOST: "postgres"
@@ -114,6 +122,7 @@ services:
       PGUSERNAME: "yukikaze"
       PGPASSWORD: "admin"
       DISCORD_TOKEN: ""
+      AMQP_URL: "rabbitmq"
 
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,18 @@ services:
       - "8080"
     restart: unless-stopped
 
+  proxy:
+    image: spectacles/proxy:latest
+    labels:
+      com.naval-base.description: "Discord proxy"
+    environment:
+      REDIS_URL: ""
+      AMQP_URL: ""
+      AMQP_GROUP: ""
+      AMQP_SUBGROUP: ""
+      AMQP_EVENT: ""
+    restart: unless-stopped
+
   parser:
     build:
       context: ./
@@ -194,5 +206,5 @@ services:
     expose:
       - "3000"
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:4000:3000"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,7 +204,7 @@ services:
       PGPASSWORD: ""
       DISCORD_TOKEN: ""
     expose:
-      - "3000"
+      - "4000"
     ports:
       - "127.0.0.1:4000:3000"
     restart: unless-stopped

--- a/docker/packages/api/Dockerfile
+++ b/docker/packages/api/Dockerfile
@@ -1,12 +1,13 @@
 FROM node:alpine
 
-RUN npx pnpm add -g pnpm && pnpm add -g pnpm
+RUN npm i -g pnpm
 
 WORKDIR /usr/yukikaze
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY packages/api ./packages/api
+COPY packages/rest ./packages/rest
 
-RUN pnpm install --frozen-lockfile --filter api
+RUN pnpm install --frozen-lockfile --filter api --filter rest
 RUN pnpm run build --filter api
 RUN pnpm prune --prod
 

--- a/docker/packages/handler/Dockerfile
+++ b/docker/packages/handler/Dockerfile
@@ -1,12 +1,13 @@
 FROM node:alpine
 
-RUN npx pnpm add -g pnpm && pnpm add -g pnpm
+RUN npm i -g pnpm
 
 WORKDIR /usr/yukikaze
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY packages/handler ./packages/handler
+COPY packages/rest ./packages/rest
 
-RUN pnpm install --frozen-lockfile --filter handler
+RUN pnpm install --frozen-lockfile --filter handler --filter rest
 RUN pnpm run build --filter handler
 RUN pnpm prune --prod
 

--- a/docker/packages/parser/Dockerfile
+++ b/docker/packages/parser/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-RUN npx pnpm add -g pnpm && pnpm add -g pnpm
+RUN npm i -g pnpm
 
 WORKDIR /usr/yukikaze
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./

--- a/docker/postgresql/Dockerfile
+++ b/docker/postgresql/Dockerfile
@@ -1,3 +1,3 @@
 FROM postgres:12-alpine
 
-COPY *.sql /docker-entrypoint-initdb.d/
+# COPY *.sql /docker-entrypoint-initdb.d/

--- a/docker/postgresql/Dockerfile
+++ b/docker/postgresql/Dockerfile
@@ -1,3 +1,3 @@
 FROM postgres:12-alpine
 
-# COPY *.sql /docker-entrypoint-initdb.d/
+COPY *.sql /docker-entrypoint-initdb.d/

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -42,7 +42,7 @@
     name: role_states
 - table:
     schema: public
-    name: settings
+    name: guild_settings
 - table:
     schema: public
     name: tags

--- a/hasura/optional_migrations/1586479065565_next/up.sql
+++ b/hasura/optional_migrations/1586479065565_next/up.sql
@@ -126,7 +126,7 @@ alter table guild_settings
 ;
 
 insert into guild_settings (
-	select guild as guild_id,
+	select guild::bigint as guild_id,
 		coalesce((settings ->> 'PREFIX')::text, '?') as prefix,
 		(settings ->> 'MOD_LOG')::bigint as mod_log_channel_id,
 		(settings ->> 'MOD_ROLE')::bigint as mod_role_id,

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,4 +13,7 @@ module.exports = {
 		},
 	},
 	roots: ['<rootDir>packages/'],
+	moduleNameMapper: {
+		'@yuudachi/rest': '<rootDir>packages/rest/src/index.ts',
+	},
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yukikaze",
-	"version": "0.1.0",
+	"version": "2.0.0",
 	"description": "",
 	"author": "iCrawl <icrawltogo@gmail.com>",
 	"license": "UNLICENSED",

--- a/packages/api/bin/index.ts
+++ b/packages/api/bin/index.ts
@@ -4,7 +4,7 @@ import { Amqp } from '@spectacles/brokers';
 import { resolve } from 'path';
 import postgres from 'postgres';
 import readdirp from 'readdirp';
-import Rest from 'rest';
+import Rest from '@yuudachi/rest';
 import { container } from 'tsyringe';
 
 import Route, { pathToRouteInfo } from '../src/Route';

--- a/packages/api/bin/index.ts
+++ b/packages/api/bin/index.ts
@@ -1,9 +1,10 @@
 import 'reflect-metadata';
 
-import Rest from '@spectacles/rest';
+import { Amqp } from '@spectacles/brokers';
 import { resolve } from 'path';
 import postgres from 'postgres';
 import readdirp from 'readdirp';
+import Rest from 'rest';
 import { container } from 'tsyringe';
 
 import Route, { pathToRouteInfo } from '../src/Route';
@@ -11,8 +12,13 @@ import createApp from '../src/app';
 import { kSQL } from '../src/tokens';
 
 const token = process.env.DISCORD_TOKEN;
+if (!token) throw new Error('no discord token');
 
-const rest = new Rest({ token });
+const amqpUrl = process.env.AMQP_URL;
+if (!amqpUrl) throw new Error('no AMQP url');
+
+const amqp = new Amqp('rest');
+const rest = new Rest(token, amqp);
 const pg = postgres({ debug: console.log });
 
 container.register(Rest, { useValue: rest });
@@ -25,6 +31,8 @@ const files = readdirp(resolve(__dirname, '..', 'src', 'routes'), {
 });
 
 void (async () => {
+	await amqp.connect(amqpUrl);
+
 	for await (const dir of files) {
 		const routeInfo = pathToRouteInfo(dir.path);
 		if (!routeInfo) continue;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@hapi/boom": "^9.1.0",
     "@hapi/joi": "^17.1.1",
-    "@spectacles/rest": "^0.8.3",
+    "@spectacles/brokers": "^0.8.0",
     "@spectacles/util": "^0.4.0",
     "common-tags": "^1.8.0",
     "ioredis": "^4.17.3",
@@ -24,6 +24,7 @@
     "postgres": "^2.0.0-beta.0",
     "readdirp": "^3.4.0",
     "reflect-metadata": "^0.1.13",
+    "rest": "link:..\\rest",
     "tslib": "^2.0.0",
     "tsyringe": "^4.3.0"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,45 +1,45 @@
 {
-  "name": "api",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "build": "rimraf dist && tsc",
-    "start": "node dist/bin/index.js",
-    "dev": "npm run build && env-cmd npm start"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "UNLICENSED",
-  "dependencies": {
-    "@hapi/boom": "^9.1.0",
-    "@hapi/joi": "^17.1.1",
-    "@spectacles/brokers": "^0.8.0",
-    "@spectacles/util": "^0.4.0",
-    "common-tags": "^1.8.0",
-    "ioredis": "^4.17.3",
-    "jsonwebtoken": "^8.5.1",
-    "lodash": "^4.17.15",
-    "polka": "^1.0.0-next.11",
-    "postgres": "^2.0.0-beta.0",
-    "readdirp": "^3.4.0",
-    "reflect-metadata": "^0.1.13",
-    "rest": "link:..\\rest",
-    "tslib": "^2.0.0",
-    "tsyringe": "^4.3.0"
-  },
-  "devDependencies": {
-    "@spectacles/types": "^0.2.1",
-    "@types/common-tags": "^1.8.0",
-    "@types/hapi__joi": "^17.1.3",
-    "@types/ioredis": "^4.17.0",
-    "@types/jsonwebtoken": "^8.5.0",
-    "@types/lodash": "^4.14.157",
-    "@types/node": "^14.0.14",
-    "@types/trouter": "^3.1.0",
-    "env-cmd": "^10.1.0",
-    "rimraf": "^3.0.2",
-    "supertest": "^4.0.2",
-    "typescript": "^3.9.6"
-  }
+	"name": "@yuudachi/api",
+	"version": "2.0.0",
+	"description": "",
+	"main": "dist/index.js",
+	"scripts": {
+		"build": "rimraf dist && tsc",
+		"start": "node dist/bin/index.js",
+		"dev": "npm run build && env-cmd npm start"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "UNLICENSED",
+	"dependencies": {
+		"@hapi/boom": "^9.1.0",
+		"@hapi/joi": "^17.1.1",
+		"@spectacles/brokers": "^0.8.0",
+		"@spectacles/util": "^0.4.0",
+		"@yuudachi/rest": "workspace:^2.0.0",
+		"common-tags": "^1.8.0",
+		"ioredis": "^4.17.3",
+		"jsonwebtoken": "^8.5.1",
+		"lodash": "^4.17.15",
+		"polka": "^1.0.0-next.11",
+		"postgres": "^2.0.0-beta.0",
+		"readdirp": "^3.4.0",
+		"reflect-metadata": "^0.1.13",
+		"tslib": "^2.0.0",
+		"tsyringe": "^4.3.0"
+	},
+	"devDependencies": {
+		"@spectacles/types": "^0.2.1",
+		"@types/common-tags": "^1.8.0",
+		"@types/hapi__joi": "^17.1.3",
+		"@types/ioredis": "^4.17.0",
+		"@types/jsonwebtoken": "^8.5.0",
+		"@types/lodash": "^4.14.157",
+		"@types/node": "^14.0.14",
+		"@types/trouter": "^3.1.0",
+		"env-cmd": "^10.1.0",
+		"rimraf": "^3.0.2",
+		"supertest": "^4.0.2",
+		"typescript": "^3.9.6"
+	}
 }

--- a/packages/api/src/managers/CaseLogManager.test.ts
+++ b/packages/api/src/managers/CaseLogManager.test.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 
-import Rest from '@spectacles/rest';
 import { stripIndents } from 'common-tags';
 import postgres, { Sql } from 'postgres';
+import Rest from '@yuudachi/rest';
 import { container } from 'tsyringe';
 
 import CaseLogManager from './CaseLogManager';
@@ -10,10 +10,10 @@ import { CaseAction } from './CaseManager';
 import { SettingsKeys } from './SettingsManager';
 import { kSQL } from '../tokens';
 
-jest.mock('@spectacles/rest');
+jest.mock('@yuudachi/rest');
 jest.mock('postgres', () => jest.fn(() => jest.fn()));
 
-const mockedRest: jest.Mocked<Rest> = new Rest() as any;
+const mockedRest: jest.Mocked<Rest> = new (Rest as any)();
 const mockedPostgres: jest.MockedFunction<Sql<any>> = postgres() as any;
 
 container.register(kSQL, { useValue: mockedPostgres });

--- a/packages/api/src/managers/CaseLogManager.ts
+++ b/packages/api/src/managers/CaseLogManager.ts
@@ -3,7 +3,7 @@ import { stripIndents } from 'common-tags';
 import { has } from 'lodash';
 import { inject, injectable } from 'tsyringe';
 import { Sql } from 'postgres';
-import Rest from 'rest';
+import Rest from '@yuudachi/rest';
 
 import { RawCase, CaseAction } from './CaseManager';
 import SettingsManager, { SettingsKeys } from './SettingsManager';

--- a/packages/api/src/managers/CaseLogManager.ts
+++ b/packages/api/src/managers/CaseLogManager.ts
@@ -1,9 +1,9 @@
-import Rest from '@spectacles/rest';
-import { Role } from '@spectacles/types';
+import { Role, Message } from '@spectacles/types';
 import { stripIndents } from 'common-tags';
 import { has } from 'lodash';
 import { inject, injectable } from 'tsyringe';
 import { Sql } from 'postgres';
+import Rest from 'rest';
 
 import { RawCase, CaseAction } from './CaseManager';
 import SettingsManager, { SettingsKeys } from './SettingsManager';
@@ -24,7 +24,7 @@ export default class CaseLogManager {
 			throw new Error('no mod log channel configured');
 		}
 
-		const logMessage = await this.rest.post(`/channels/${logChannelId}/messages`, {
+		const logMessage: Message = await this.rest.post(`/channels/${logChannelId}/messages`, {
 			embed: {
 				title: `${item.mod_tag} (${item.mod_id})`,
 				description: await this.generateLogMessage(item, logChannelId),

--- a/packages/api/src/managers/CaseManager.test.ts
+++ b/packages/api/src/managers/CaseManager.test.ts
@@ -1,16 +1,16 @@
 import 'reflect-metadata';
 
-import Rest from '@spectacles/rest';
+import Rest from '@yuudachi/rest';
 import postgres, { Sql } from 'postgres';
 import { container } from 'tsyringe';
 
 import CaseManager, { CaseAction, Case } from './CaseManager';
 import { kSQL } from '../tokens';
 
-jest.mock('@spectacles/rest');
+jest.mock('@yuudachi/rest');
 jest.mock('postgres', () => jest.fn(() => jest.fn()));
 
-const mockedRest: jest.Mocked<Rest> = new Rest() as any;
+const mockedRest: jest.Mocked<Rest> = new (Rest as any)();
 const mockedPostgres: jest.MockedFunction<Sql<any>> = postgres() as any;
 
 container.register(kSQL, { useValue: mockedPostgres });

--- a/packages/api/src/managers/CaseManager.ts
+++ b/packages/api/src/managers/CaseManager.ts
@@ -1,6 +1,6 @@
-import Rest from '@spectacles/rest';
 import { User } from '@spectacles/types';
 import { Sql } from 'postgres';
+import Rest from 'rest';
 import { inject, injectable } from 'tsyringe';
 import { URLSearchParams } from 'url';
 
@@ -102,8 +102,8 @@ export default class CaseManager {
 		}
 
 		const [target, mod]: [User, User] = await Promise.all([
-			this.rest.get(`/users/${case_.targetId}`),
-			this.rest.get(`/users/${case_.moderatorId}`),
+			this.rest.get<User>(`/users/${case_.targetId}`),
+			this.rest.get<User>(`/users/${case_.moderatorId}`),
 		]);
 
 		const [newCase] = await this.sql`

--- a/packages/api/src/managers/CaseManager.ts
+++ b/packages/api/src/managers/CaseManager.ts
@@ -1,6 +1,6 @@
 import { User } from '@spectacles/types';
 import { Sql } from 'postgres';
-import Rest from 'rest';
+import Rest from '@yuudachi/rest';
 import { inject, injectable } from 'tsyringe';
 import { URLSearchParams } from 'url';
 

--- a/packages/handler/bin/index.ts
+++ b/packages/handler/bin/index.ts
@@ -7,7 +7,7 @@ import postgres from 'postgres';
 import { outputFromJSON, ParserOutput } from 'lexure';
 import { resolve } from 'path';
 import readdirp from 'readdirp';
-import Rest from 'rest';
+import Rest from '@yuudachi/rest';
 import { container } from 'tsyringe';
 
 import Command, { commandInfo } from '../src/Command';

--- a/packages/handler/package.json
+++ b/packages/handler/package.json
@@ -13,11 +13,11 @@
 	"license": "UNLICENSED",
 	"dependencies": {
 		"@spectacles/brokers": "^0.8.0",
-		"@spectacles/rest": "^0.8.3",
 		"lexure": "^0.8.0",
 		"postgres": "^2.0.0-beta.0",
 		"readdirp": "^3.4.0",
 		"reflect-metadata": "^0.1.13",
+		"rest": "link:..\\rest",
 		"tslib": "^2.0.0",
 		"tsyringe": "^4.3.0"
 	},

--- a/packages/handler/package.json
+++ b/packages/handler/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "handler",
-	"version": "1.0.0",
+	"name": "@yuudachi/handler",
+	"version": "2.0.0",
 	"description": "",
-	"main": "index.js",
+	"main": "dist/index.js",
 	"scripts": {
 		"build": "rimraf dist && tsc",
 		"start": "node dist/bin/index.js",
@@ -13,11 +13,11 @@
 	"license": "UNLICENSED",
 	"dependencies": {
 		"@spectacles/brokers": "^0.8.0",
+		"@yuudachi/rest": "workspace:^2.0.0",
 		"lexure": "^0.8.0",
 		"postgres": "^2.0.0-beta.0",
 		"readdirp": "^3.4.0",
 		"reflect-metadata": "^0.1.13",
-		"rest": "link:..\\rest",
 		"tslib": "^2.0.0",
 		"tsyringe": "^4.3.0"
 	},

--- a/packages/handler/src/commands/util/ping.ts
+++ b/packages/handler/src/commands/util/ping.ts
@@ -1,6 +1,6 @@
 import { injectable } from 'tsyringe';
-import Rest from '@spectacles/rest';
 import { Message } from '@spectacles/types';
+import Rest from 'rest';
 
 import Command from '../../Command';
 

--- a/packages/handler/src/commands/util/ping.ts
+++ b/packages/handler/src/commands/util/ping.ts
@@ -1,6 +1,6 @@
 import { injectable } from 'tsyringe';
 import { Message } from '@spectacles/types';
-import Rest from 'rest';
+import Rest from '@yuudachi/rest';
 
 import Command from '../../Command';
 

--- a/packages/parser/bin/index.ts
+++ b/packages/parser/bin/index.ts
@@ -20,7 +20,7 @@ void (async () => {
 		const [data] = (await sql`select prefix
 			from guild_settings
 			where guild_id = ${message.guild_id ?? null};`) as [{ prefix: string | null }];
-		const prefix = data.prefix ?? '?';
+		const prefix = data?.prefix ?? '?';
 		const lexer = new Lexer(message.content).setQuotes([
 			['"', '"'],
 			['“', '”'],

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "parser",
-	"version": "1.0.0",
+	"name": "@yuudachi/parser",
+	"version": "2.0.0",
 	"description": "",
-	"main": "index.js",
+	"main": "dist/index.js",
 	"scripts": {
 		"build": "rimraf dist && tsc",
 		"start": "node dist/bin/index.js",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "rest",
+  "version": "0.1.0",
+  "description": "",
+  "main": "dist/index.js",
+  "typings": "typings/index.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "rimraf dist typings && tsc",
+    "prepare": "pnpm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Naval-Base/yuudachi.git"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "bugs": {
+    "url": "https://github.com/Naval-Base/yuudachi/issues"
+  },
+  "homepage": "https://github.com/Naval-Base/yuudachi#readme",
+  "devDependencies": {
+    "@spectacles/brokers": "^0.8.0",
+    "rimraf": "^3.0.2",
+    "typescript": "^3.9.7"
+  },
+  "dependencies": {
+    "tslib": "^2.0.0"
+  }
+}

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -6,8 +6,7 @@
   "typings": "typings/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rimraf dist typings && tsc",
-    "prepare": "pnpm run build"
+    "prepare": "rimraf dist typings && tsc"
   },
   "repository": {
     "type": "git",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,29 +1,20 @@
 {
-  "name": "rest",
-  "version": "0.1.0",
-  "description": "",
-  "main": "dist/index.js",
-  "typings": "typings/index.d.ts",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "prepare": "rimraf dist typings && tsc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Naval-Base/yuudachi.git"
-  },
-  "author": "",
-  "license": "UNLICENSED",
-  "bugs": {
-    "url": "https://github.com/Naval-Base/yuudachi/issues"
-  },
-  "homepage": "https://github.com/Naval-Base/yuudachi#readme",
-  "devDependencies": {
-    "@spectacles/brokers": "^0.8.0",
-    "rimraf": "^3.0.2",
-    "typescript": "^3.9.7"
-  },
-  "dependencies": {
-    "tslib": "^2.0.0"
-  }
+	"name": "@yuudachi/rest",
+	"version": "2.0.0",
+	"description": "",
+	"main": "dist/index.js",
+	"typings": "typings/index.d.ts",
+	"scripts": {
+		"prepare": "rimraf dist typings && tsc"
+	},
+	"author": "",
+	"license": "UNLICENSED",
+	"dependencies": {
+		"tslib": "^2.0.0"
+	},
+	"devDependencies": {
+		"@spectacles/brokers": "^0.8.0",
+		"rimraf": "^3.0.2",
+		"typescript": "^3.9.7"
+	}
 }

--- a/packages/rest/src/Rest.test.ts
+++ b/packages/rest/src/Rest.test.ts
@@ -5,6 +5,10 @@ jest.mock('@spectacles/brokers');
 
 const mockedAmqp: jest.Mocked<Amqp> = new (Amqp as any)();
 
+afterEach(() => {
+	mockedAmqp.call.mockClear();
+});
+
 test('constructs', () => {
 	expect(() => new Rest('token', mockedAmqp)).not.toThrow();
 });
@@ -15,14 +19,17 @@ test('has properties', () => {
 	expect(rest).toHaveProperty('broker', mockedAmqp);
 });
 
-test('sends get', () => {
+test('sends get', async () => {
 	const rest = new Rest('token', mockedAmqp);
-	void rest.get('/foo/bar');
 
 	mockedAmqp.call.mockResolvedValue({
 		status: 0,
-		body: {},
+		body: {
+			body: { abc: 'def' },
+		},
 	});
+
+	const res = await rest.get('/foo/bar');
 
 	expect(mockedAmqp.call).toHaveBeenCalledTimes(1);
 	expect(mockedAmqp.call).toHaveBeenCalledWith('REQUEST', {
@@ -34,4 +41,161 @@ test('sends get', () => {
 			'Content-Type': 'application/json',
 		},
 	});
+
+	expect(res).toStrictEqual({ abc: 'def' });
+});
+
+test('sends post', async () => {
+	const rest = new Rest('token', mockedAmqp);
+
+	mockedAmqp.call.mockResolvedValue({
+		status: 0,
+		body: { body: 'baz' },
+	});
+
+	const res = await rest.post('/foo/bar', { foo: 'bar' });
+
+	expect(mockedAmqp.call).toHaveBeenCalledTimes(1);
+	expect(mockedAmqp.call).toHaveBeenCalledWith('REQUEST', {
+		method: 'POST',
+		path: '/foo/bar',
+		body: { foo: 'bar' },
+		headers: {
+			Authorization: 'Bot token',
+			'X-RateLimit-Precision': 'millisecond',
+			'Content-Type': 'application/json',
+		},
+	});
+
+	expect(res).toBe('baz');
+});
+
+test('sends put', async () => {
+	const rest = new Rest('token', mockedAmqp);
+
+	mockedAmqp.call.mockResolvedValue({
+		status: 0,
+		body: {
+			body: null,
+		},
+	});
+
+	const res = await rest.put('/foo/bar', { foo: 'bar' });
+
+	expect(mockedAmqp.call).toHaveBeenCalledTimes(1);
+	expect(mockedAmqp.call).toHaveBeenCalledWith('REQUEST', {
+		method: 'PUT',
+		path: '/foo/bar',
+		body: { foo: 'bar' },
+		headers: {
+			Authorization: 'Bot token',
+			'X-RateLimit-Precision': 'millisecond',
+			'Content-Type': 'application/json',
+		},
+	});
+
+	expect(res).toBe(null);
+});
+
+test('sends patch', async () => {
+	const rest = new Rest('token', mockedAmqp);
+
+	mockedAmqp.call.mockResolvedValue({
+		status: 0,
+		body: {
+			body: null,
+		},
+	});
+
+	const res = await rest.patch('/foo/bar', { foo: 'bar' });
+
+	expect(mockedAmqp.call).toHaveBeenCalledTimes(1);
+	expect(mockedAmqp.call).toHaveBeenCalledWith('REQUEST', {
+		method: 'PATCH',
+		path: '/foo/bar',
+		body: { foo: 'bar' },
+		headers: {
+			Authorization: 'Bot token',
+			'X-RateLimit-Precision': 'millisecond',
+			'Content-Type': 'application/json',
+		},
+	});
+
+	expect(res).toBe(null);
+});
+
+test('sends delete', async () => {
+	const rest = new Rest('token', mockedAmqp);
+
+	mockedAmqp.call.mockResolvedValue({
+		status: 0,
+		body: {
+			body: null,
+		},
+	});
+
+	const res = await rest.delete('/foo/bar');
+
+	expect(mockedAmqp.call).toHaveBeenCalledTimes(1);
+	expect(mockedAmqp.call).toHaveBeenCalledWith('REQUEST', {
+		method: 'DELETE',
+		path: '/foo/bar',
+		headers: {
+			Authorization: 'Bot token',
+			'X-RateLimit-Precision': 'millisecond',
+			'Content-Type': 'application/json',
+		},
+	});
+
+	expect(res).toBe(null);
+});
+
+test('throws error', async () => {
+	const rest = new Rest('token', mockedAmqp);
+
+	mockedAmqp.call.mockResolvedValue({
+		status: 1,
+		body: 'it broke!',
+	});
+
+	await expect(() => rest.get('/foo/bar')).rejects.toStrictEqual(new Error('it broke!'));
+
+	expect(mockedAmqp.call).toHaveBeenCalledTimes(1);
+	expect(mockedAmqp.call).toHaveBeenCalledWith('REQUEST', {
+		method: 'GET',
+		path: '/foo/bar',
+		headers: {
+			Authorization: 'Bot token',
+			'X-RateLimit-Precision': 'millisecond',
+			'Content-Type': 'application/json',
+		},
+	});
+});
+
+test('sends audit log reason', async () => {
+	const rest = new Rest('token', mockedAmqp);
+
+	mockedAmqp.call.mockResolvedValue({
+		status: 0,
+		body: {
+			body: 'foo',
+		},
+	});
+
+	const res = await rest.put('/foo/bar', null, { reason: 'some reason' });
+
+	expect(mockedAmqp.call).toHaveBeenCalledTimes(1);
+	expect(mockedAmqp.call).toHaveBeenCalledWith('REQUEST', {
+		method: 'PUT',
+		path: '/foo/bar',
+		body: null,
+		headers: {
+			Authorization: 'Bot token',
+			'X-RateLimit-Precision': 'millisecond',
+			'Content-Type': 'application/json',
+			'X-Audit-Log-Reason': 'some reason',
+		},
+	});
+
+	expect(res).toBe('foo');
 });

--- a/packages/rest/src/Rest.test.ts
+++ b/packages/rest/src/Rest.test.ts
@@ -1,0 +1,37 @@
+import { Amqp } from '@spectacles/brokers';
+import Rest from './Rest';
+
+jest.mock('@spectacles/brokers');
+
+const mockedAmqp: jest.Mocked<Amqp> = new (Amqp as any)();
+
+test('constructs', () => {
+	expect(() => new Rest('token', mockedAmqp)).not.toThrow();
+});
+
+test('has properties', () => {
+	const rest = new Rest('token', mockedAmqp);
+	expect(rest).toHaveProperty('token', 'token');
+	expect(rest).toHaveProperty('broker', mockedAmqp);
+});
+
+test('sends get', () => {
+	const rest = new Rest('token', mockedAmqp);
+	void rest.get('/foo/bar');
+
+	mockedAmqp.call.mockResolvedValue({
+		status: 0,
+		body: {},
+	});
+
+	expect(mockedAmqp.call).toHaveBeenCalledTimes(1);
+	expect(mockedAmqp.call).toHaveBeenCalledWith('REQUEST', {
+		method: 'GET',
+		path: '/foo/bar',
+		headers: {
+			Authorization: 'Bot token',
+			'X-RateLimit-Precision': 'millisecond',
+			'Content-Type': 'application/json',
+		},
+	});
+});

--- a/packages/rest/src/Rest.ts
+++ b/packages/rest/src/Rest.ts
@@ -1,73 +1,70 @@
 import { Amqp } from '@spectacles/brokers';
 
 interface Request {
-  method: string;
-  path: string;
-  body?: any;
-  headers?: Record<string, string>;
-  options?: RequestOptions;
+	method: string;
+	path: string;
+	body?: any;
+	headers?: Record<string, string>;
+	options?: RequestOptions;
 }
 
 interface ResponseBody {
-  status: number;
-  headers: Record<string, string>;
-  url: string;
-  body: unknown;
+	status: number;
+	headers: Record<string, string>;
+	url: string;
+	body: unknown;
 }
 
 interface Response {
-  status: number;
-  body: unknown;
+	status: number;
+	body: unknown;
 }
 
 interface RequestOptions {
-  reason?: string;
+	reason?: string;
 }
 
 export default class Rest {
-  constructor(
-    public readonly token: string,
-    public readonly broker: Amqp
-  ) {}
+	public constructor(public readonly token: string, public readonly broker: Amqp) {}
 
-  public get<T = unknown>(path: string, options?: RequestOptions): Promise<T> {
-    return this.do({ method: 'GET', path, options });
-  }
+	public get<T = unknown>(path: string, options?: RequestOptions): Promise<T> {
+		return this.do({ method: 'GET', path, options });
+	}
 
-  public post<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
-    return this.do({ method: 'POST', path, body, options });
-  }
+	public post<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
+		return this.do({ method: 'POST', path, body, options });
+	}
 
-  public put<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
-    return this.do({ method: 'PUT', path, body, options });
-  }
+	public put<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
+		return this.do({ method: 'PUT', path, body, options });
+	}
 
-  public patch<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
-    return this.do({ method: 'PATCH', path, body, options });
-  }
+	public patch<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
+		return this.do({ method: 'PATCH', path, body, options });
+	}
 
-  public delete<T = unknown>(path: string, options?: RequestOptions): Promise<T> {
-    return this.do({ method: 'DELETE', path, options });
-  }
+	public delete<T = unknown>(path: string, options?: RequestOptions): Promise<T> {
+		return this.do({ method: 'DELETE', path, options });
+	}
 
-  protected async do<T>(req: Request): Promise<T> {
-    const options = req.options;
-    delete req.options;
+	protected async do<T>(req: Request): Promise<T> {
+		const options = req.options;
+		delete req.options;
 
-    const headers = options?.reason ? { 'X-Audit-Log-Reason': options.reason } : {};
+		const headers = options?.reason ? { 'X-Audit-Log-Reason': options.reason } : {};
 
-    const res: Response = await this.broker.call('REQUEST', {
-      ...req,
-      headers: {
-        ...headers,
-        'Authorization': `Bot ${this.token}`,
-        'X-RateLimit-Precision': 'millisecond',
-        'Content-Type': 'application/json',
-      },
-    });
+		const res: Response = await this.broker.call('REQUEST', {
+			...req,
+			headers: {
+				...headers,
+				Authorization: `Bot ${this.token}`,
+				'X-RateLimit-Precision': 'millisecond',
+				'Content-Type': 'application/json',
+			},
+		});
 
-    // TODO: handle non-2xx status codes
-    if (res.status === 0) return (res.body as ResponseBody).body as T;
-    throw new Error(res.body as string);
-  }
+		// TODO: handle non-2xx status codes
+		if (res.status === 0) return (res.body as ResponseBody).body as T;
+		throw new Error(res.body as string);
+	}
 }

--- a/packages/rest/src/Rest.ts
+++ b/packages/rest/src/Rest.ts
@@ -1,0 +1,73 @@
+import { Amqp } from '@spectacles/brokers';
+
+interface Request {
+  method: string;
+  path: string;
+  body?: any;
+  headers?: Record<string, string>;
+  options?: RequestOptions;
+}
+
+interface ResponseBody {
+  status: number;
+  headers: Record<string, string>;
+  url: string;
+  body: unknown;
+}
+
+interface Response {
+  status: number;
+  body: unknown;
+}
+
+interface RequestOptions {
+  reason?: string;
+}
+
+export default class Rest {
+  constructor(
+    public readonly token: string,
+    public readonly broker: Amqp
+  ) {}
+
+  public get<T = unknown>(path: string, options?: RequestOptions): Promise<T> {
+    return this.do({ method: 'GET', path, options });
+  }
+
+  public post<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
+    return this.do({ method: 'POST', path, body, options });
+  }
+
+  public put<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
+    return this.do({ method: 'PUT', path, body, options });
+  }
+
+  public patch<T = unknown>(path: string, body: any, options?: RequestOptions): Promise<T> {
+    return this.do({ method: 'PATCH', path, body, options });
+  }
+
+  public delete<T = unknown>(path: string, options?: RequestOptions): Promise<T> {
+    return this.do({ method: 'DELETE', path, options });
+  }
+
+  protected async do<T>(req: Request): Promise<T> {
+    const options = req.options;
+    delete req.options;
+
+    const headers = options?.reason ? { 'X-Audit-Log-Reason': options.reason } : {};
+
+    const res: Response = await this.broker.call('REQUEST', {
+      ...req,
+      headers: {
+        ...headers,
+        'Authorization': `Bot ${this.token}`,
+        'X-RateLimit-Precision': 'millisecond',
+        'Content-Type': 'application/json',
+      },
+    });
+
+    // TODO: handle non-2xx status codes
+    if (res.status === 0) return (res.body as ResponseBody).body as T;
+    throw new Error(res.body as string);
+  }
+}

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,0 +1,4 @@
+import Rest from './Rest';
+
+export { Rest };
+export default Rest;

--- a/packages/rest/tsconfig.eslint.json
+++ b/packages/rest/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"**/*.ts",
+		"**/*.test.ts",
+		"**/*.spec.ts",
+	],
+	"exclude": []
+}

--- a/packages/rest/tsconfig.json
+++ b/packages/rest/tsconfig.json
@@ -5,10 +5,9 @@
 		"declarationDir": "typings",
 		"module": "CommonJS",
 		"sourceRoot": "./",
-		"outDir": "dist"
+		"outDir": "dist/src"
 	},
 	"include": [
-		"./src",
-		"./bin"
+		"./src"
 	]
 }

--- a/packages/rest/tsconfig.json
+++ b/packages/rest/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationDir": "typings",
+		"module": "CommonJS",
+		"sourceRoot": "./",
+		"outDir": "dist"
+	},
+	"include": [
+		"./src",
+		"./bin"
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,21 +1,21 @@
 importers:
   .:
     devDependencies:
-      '@babel/core': 7.10.4
-      '@babel/plugin-proposal-decorators': 7.10.4_@babel+core@7.10.4
-      '@babel/preset-env': 7.10.4_@babel+core@7.10.4
-      '@babel/preset-typescript': 7.10.4_@babel+core@7.10.4
-      '@types/jest': 26.0.3
+      '@babel/core': 7.11.0
+      '@babel/plugin-proposal-decorators': 7.10.5_@babel+core@7.11.0
+      '@babel/preset-env': 7.11.0_@babel+core@7.11.0
+      '@babel/preset-typescript': 7.10.4_@babel+core@7.11.0
+      '@types/jest': 26.0.8
       '@types/supertest': 2.0.10
-      '@typescript-eslint/eslint-plugin': 3.5.0_3cfcbecb75673e79af5489ac2f3ac848
-      '@typescript-eslint/parser': 3.5.0_eslint@7.4.0
-      babel-jest: 26.1.0_@babel+core@7.10.4
+      '@typescript-eslint/eslint-plugin': 3.7.1_d22ed00097c81894d28d3f9848aea27e
+      '@typescript-eslint/parser': 3.7.1_eslint@7.6.0
+      babel-jest: 26.2.2_@babel+core@7.11.0
       babel-plugin-transform-typescript-metadata: 0.3.0
-      eslint: 7.4.0
+      eslint: 7.6.0
       eslint-config-marine: 7.1.2
-      eslint-config-prettier: 6.11.0_eslint@7.4.0
-      eslint-plugin-prettier: 3.1.4_eslint@7.4.0+prettier@2.0.5
-      jest: 26.1.0
+      eslint-config-prettier: 6.11.0_eslint@7.6.0
+      eslint-plugin-prettier: 3.1.4_eslint@7.6.0+prettier@2.0.5
+      jest: 26.2.2
       prettier: 2.0.5
       supertest: 4.0.2
     specifiers:
@@ -42,30 +42,30 @@ importers:
       '@hapi/joi': 17.1.1
       '@spectacles/brokers': 0.8.0
       '@spectacles/util': 0.4.0
+      '@yuudachi/rest': 'link:../rest'
       common-tags: 1.8.0
       ioredis: 4.17.3
       jsonwebtoken: 8.5.1
-      lodash: 4.17.15
+      lodash: 4.17.19
       polka: 1.0.0-next.11
       postgres: 2.0.0-beta.0
       readdirp: 3.4.0
       reflect-metadata: 0.1.13
-      rest: 'link:../rest'
       tslib: 2.0.0
       tsyringe: 4.3.0
     devDependencies:
       '@spectacles/types': 0.2.1
       '@types/common-tags': 1.8.0
-      '@types/hapi__joi': 17.1.3
-      '@types/ioredis': 4.17.0
+      '@types/hapi__joi': 17.1.4
+      '@types/ioredis': 4.17.3
       '@types/jsonwebtoken': 8.5.0
-      '@types/lodash': 4.14.157
-      '@types/node': 14.0.14
+      '@types/lodash': 4.14.158
+      '@types/node': 14.0.27
       '@types/trouter': 3.1.0
       env-cmd: 10.1.0
       rimraf: 3.0.2
       supertest: 4.0.2
-      typescript: 3.9.6
+      typescript: 3.9.7
     specifiers:
       '@hapi/boom': ^9.1.0
       '@hapi/joi': ^17.1.1
@@ -79,6 +79,7 @@ importers:
       '@types/lodash': ^4.14.157
       '@types/node': ^14.0.14
       '@types/trouter': ^3.1.0
+      '@yuudachi/rest': 'workspace:^2.0.0'
       common-tags: ^1.8.0
       env-cmd: ^10.1.0
       ioredis: ^4.17.3
@@ -88,7 +89,6 @@ importers:
       postgres: ^2.0.0-beta.0
       readdirp: ^3.4.0
       reflect-metadata: ^0.1.13
-      rest: 'link:..\rest'
       rimraf: ^3.0.2
       supertest: ^4.0.2
       tslib: ^2.0.0
@@ -97,29 +97,29 @@ importers:
   packages/handler:
     dependencies:
       '@spectacles/brokers': 0.8.0
+      '@yuudachi/rest': 'link:../rest'
       lexure: 0.8.0
       postgres: 2.0.0-beta.0
       readdirp: 3.4.0
       reflect-metadata: 0.1.13
-      rest: 'link:../rest'
       tslib: 2.0.0
       tsyringe: 4.3.0
     devDependencies:
       '@spectacles/types': 0.2.1
-      '@types/node': 14.0.14
+      '@types/node': 14.0.27
       env-cmd: 10.1.0
       rimraf: 3.0.2
-      typescript: 3.9.6
+      typescript: 3.9.7
     specifiers:
       '@spectacles/brokers': ^0.8.0
       '@spectacles/types': ^0.2.1
       '@types/node': ^14.0.14
+      '@yuudachi/rest': 'workspace:^2.0.0'
       env-cmd: ^10.1.0
       lexure: ^0.8.0
       postgres: ^2.0.0-beta.0
       readdirp: ^3.4.0
       reflect-metadata: ^0.1.13
-      rest: 'link:..\rest'
       rimraf: ^3.0.2
       tslib: ^2.0.0
       tsyringe: ^4.3.0
@@ -132,10 +132,10 @@ importers:
       tslib: 2.0.0
     devDependencies:
       '@spectacles/types': 0.2.1
-      '@types/node': 14.0.14
+      '@types/node': 14.0.27
       env-cmd: 10.1.0
       rimraf: 3.0.2
-      typescript: 3.9.6
+      typescript: 3.9.7
     specifiers:
       '@spectacles/brokers': ^0.8.0
       '@spectacles/types': ^0.2.1
@@ -166,29 +166,29 @@ packages:
     dev: true
     resolution:
       integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
-  /@babel/compat-data/7.10.4:
+  /@babel/compat-data/7.11.0:
     dependencies:
-      browserslist: 4.12.2
+      browserslist: 4.13.0
       invariant: 2.2.4
       semver: 5.7.1
     dev: true
     resolution:
-      integrity: sha512-t+rjExOrSVvjQQXNp5zAIYDp00KjdvGl/TpDX5REPr0S9IAIPQMTilcfG6q8c0QFmj9lSTVySV2VTsyggvtNIw==
-  /@babel/core/7.10.4:
+      integrity: sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==
+  /@babel/core/7.11.0:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/generator': 7.10.4
-      '@babel/helper-module-transforms': 7.10.4
+      '@babel/generator': 7.11.0
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helpers': 7.10.4
-      '@babel/parser': 7.10.4
+      '@babel/parser': 7.11.0
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
       convert-source-map: 1.7.0
       debug: 4.1.1
       gensync: 1.0.0-beta.1
       json5: 2.1.3
-      lodash: 4.17.15
+      lodash: 4.17.19
       resolve: 1.17.0
       semver: 5.7.1
       source-map: 0.5.7
@@ -196,34 +196,33 @@ packages:
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==
-  /@babel/generator/7.10.4:
+      integrity: sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==
+  /@babel/generator/7.11.0:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
       jsesc: 2.5.2
-      lodash: 4.17.15
       source-map: 0.5.7
     dev: true
     resolution:
-      integrity: sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==
+      integrity: sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==
   /@babel/helper-annotate-as-pure/7.10.4:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.10.4:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==
-  /@babel/helper-compilation-targets/7.10.4_@babel+core@7.10.4:
+  /@babel/helper-compilation-targets/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/compat-data': 7.10.4
-      '@babel/core': 7.10.4
-      browserslist: 4.12.2
+      '@babel/compat-data': 7.11.0
+      '@babel/core': 7.11.0
+      browserslist: 4.13.0
       invariant: 2.2.4
       levenary: 1.1.1
       semver: 5.7.1
@@ -232,43 +231,43 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
-  /@babel/helper-create-class-features-plugin/7.10.4_@babel+core@7.10.4:
+  /@babel/helper-create-class-features-plugin/7.10.5_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-function-name': 7.10.4
-      '@babel/helper-member-expression-to-functions': 7.10.4
+      '@babel/helper-member-expression-to-functions': 7.11.0
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-9raUiOsXPxzzLjCXeosApJItoMnX3uyT4QdM2UldffuGApNrF8e938MwNpDCK9CPoyxrEoCgT+hObJc3mZa6lQ==
-  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
+  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-regex': 7.10.4
+      '@babel/helper-regex': 7.10.5
       regexpu-core: 4.7.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
-  /@babel/helper-define-map/7.10.4:
+  /@babel/helper-define-map/7.10.5:
     dependencies:
       '@babel/helper-function-name': 7.10.4
-      '@babel/types': 7.10.4
-      lodash: 4.17.15
+      '@babel/types': 7.11.0
+      lodash: 4.17.19
     dev: true
     resolution:
-      integrity: sha512-nIij0oKErfCnLUCWaCaHW0Bmtl2RO9cN7+u2QT8yqTywgALKlyUVOvHDElh+b5DwVC6YB1FOYFOTWcN/+41EDA==
+      integrity: sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==
   /@babel/helper-explode-assignable-expression/7.10.4:
     dependencies:
-      '@babel/traverse': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==
@@ -276,49 +275,49 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.10.4
       '@babel/template': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
   /@babel/helper-get-function-arity/7.10.4:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
   /@babel/helper-hoist-variables/7.10.4:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==
-  /@babel/helper-member-expression-to-functions/7.10.4:
+  /@babel/helper-member-expression-to-functions/7.11.0:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
-      integrity: sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==
+      integrity: sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==
   /@babel/helper-module-imports/7.10.4:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
-  /@babel/helper-module-transforms/7.10.4:
+  /@babel/helper-module-transforms/7.11.0:
     dependencies:
       '@babel/helper-module-imports': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
       '@babel/helper-simple-access': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
       '@babel/template': 7.10.4
-      '@babel/types': 7.10.4
-      lodash: 4.17.15
+      '@babel/types': 7.11.0
+      lodash: 4.17.19
     dev: true
     resolution:
-      integrity: sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==
+      integrity: sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==
   /@babel/helper-optimise-call-expression/7.10.4:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
@@ -326,44 +325,50 @@ packages:
     dev: true
     resolution:
       integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
-  /@babel/helper-regex/7.10.4:
+  /@babel/helper-regex/7.10.5:
     dependencies:
-      lodash: 4.17.15
+      lodash: 4.17.19
     dev: true
     resolution:
-      integrity: sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==
+      integrity: sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==
   /@babel/helper-remap-async-to-generator/7.10.4:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.10.4
       '@babel/helper-wrap-function': 7.10.4
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==
   /@babel/helper-replace-supers/7.10.4:
     dependencies:
-      '@babel/helper-member-expression-to-functions': 7.10.4
+      '@babel/helper-member-expression-to-functions': 7.11.0
       '@babel/helper-optimise-call-expression': 7.10.4
-      '@babel/traverse': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==
   /@babel/helper-simple-access/7.10.4:
     dependencies:
       '@babel/template': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==
-  /@babel/helper-split-export-declaration/7.10.4:
+  /@babel/helper-skip-transparent-expression-wrappers/7.11.0:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
-      integrity: sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
+      integrity: sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==
+  /@babel/helper-split-export-declaration/7.11.0:
+    dependencies:
+      '@babel/types': 7.11.0
+    dev: true
+    resolution:
+      integrity: sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
   /@babel/helper-validator-identifier/7.10.4:
     dev: true
     resolution:
@@ -372,16 +377,16 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.10.4
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==
   /@babel/helpers/7.10.4:
     dependencies:
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==
@@ -393,130 +398,151 @@ packages:
     dev: true
     resolution:
       integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
-  /@babel/parser/7.10.4:
+  /@babel/parser/7.11.0:
     dev: true
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==
-  /@babel/plugin-proposal-async-generator-functions/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==
+  /@babel/plugin-proposal-async-generator-functions/7.10.5_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.10.4
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-MJbxGSmejEFVOANAezdO39SObkURO5o/8b6fSH6D1pi9RZQt+ldppKPXfqgUWpSQ9asM6xaSaSJIaeWMDRP0Zg==
-  /@babel/plugin-proposal-class-properties/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
+  /@babel/plugin-proposal-class-properties/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-create-class-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
-  /@babel/plugin-proposal-decorators/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-proposal-decorators/7.10.5_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-create-class-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-decorators': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-decorators': 7.10.4_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-JHTWjQngOPv+ZQQqOGv2x6sCCr4IYWy7S1/VH6BE9ZfkoLrdQ2GpEP3tfb5M++G9PwvqjhY8VC/C3tXm+/eHvA==
-  /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==
+  /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
-  /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-proposal-export-namespace-from/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
+  /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-proposal-logical-assignment-operators/7.11.0_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
-  /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
-  /@babel/plugin-proposal-object-rest-spread/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-proposal-object-rest-spread/7.11.0_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-transform-parameters': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==
-  /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
+  /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
-  /@babel/plugin-proposal-optional-chaining/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-proposal-optional-chaining/7.11.0_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.10.4
+      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==
-  /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
+  /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-create-class-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
-  /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     engines:
@@ -525,153 +551,162 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.10.4:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.10.4:
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
-  /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
-  /@babel/plugin-syntax-decorators/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-syntax-decorators/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2NaoC6fAk2VMdhY1eerkfHV+lVYC1u8b+jmRJISqANCJlTxYy19HGdIkkQtix2UtkcPuPu+IlDgrVseZnU03bw==
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.10.4:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.10.4:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.10.4:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.10.4:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.10.4:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.10.4:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
-  /@babel/plugin-syntax-typescript/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-syntax-typescript/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==
-  /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
-  /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-module-imports': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.10.4
@@ -680,81 +715,80 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
-  /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
-  /@babel/plugin-transform-block-scoping/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-block-scoping/7.10.5_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      lodash: 4.17.15
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-J3b5CluMg3hPUii2onJDRiaVbPtKFPLEaV5dOPY5OeAbDi1iU/UbbFFTgwb7WnanaDy7bjU35kc26W3eM5Qa0A==
-  /@babel/plugin-transform-classes/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==
+  /@babel/plugin-transform-classes/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-define-map': 7.10.4
+      '@babel/helper-define-map': 7.10.5
       '@babel/helper-function-name': 7.10.4
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
       globals: 11.12.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
-  /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
-  /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
-  /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
-  /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
-  /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
@@ -762,18 +796,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
-  /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
-  /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-function-name': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
@@ -781,39 +815,39 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
-  /@babel/plugin-transform-literals/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-literals/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
-  /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
-  /@babel/plugin-transform-modules-amd/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-module-transforms': 7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-3Fw+H3WLUrTlzi3zMiZWp3AR4xadAEMv6XRCYnd5jAlLM61Rn+CRJaZMaNvIpcJpQ3vs1kyifYvEVPFfoSkKOA==
-  /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
+  /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-module-transforms': 7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-simple-access': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
@@ -822,49 +856,49 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
-  /@babel/plugin-transform-modules-systemjs/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-modules-systemjs/7.10.5_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.10.4
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Tb28LlfxrTiOTGtZFsvkjpyjCl9IoaRI52AEU/VIwOwvDQWtbNJsAqTXzh+5R7i74e/OZHH2c2w2fsOqAfnQYQ==
-  /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
+  /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-module-transforms': 7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
-  /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
-  /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
     dev: true
@@ -872,183 +906,188 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
-  /@babel/plugin-transform-parameters/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-parameters/7.10.5_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-get-function-arity': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-RurVtZ/D5nYfEg0iVERXYKEgDFeesHrHfx8RT05Sq57ucj2eOYAP6eu5fynL4Adju4I/mP/I6SO0DqNWAXjfLQ==
-  /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
+  /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
-  /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       regenerator-transform: 0.14.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
-  /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
-  /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
-  /@babel/plugin-transform-spread/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-spread/7.11.0_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==
-  /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
+  /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-regex': 7.10.4
+      '@babel/helper-regex': 7.10.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
-  /@babel/plugin-transform-template-literals/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-template-literals/7.10.5_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-annotate-as-pure': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-4NErciJkAYe+xI5cqfS8pV/0ntlY5N5Ske/4ImxAVX7mk9Rxt2bwDTGv1Msc2BRJvWQcmYEC+yoMLdX22aE4VQ==
-  /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
+  /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
-  /@babel/plugin-transform-typescript/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-typescript/7.11.0_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-create-class-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-typescript': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-typescript': 7.10.4_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-3WpXIKDJl/MHoAN0fNkSr7iHdUMHZoppXjf2HJ9/ed5Xht5wNIsXllJXdityKOxeA3Z8heYRb1D3p2H5rfCdPw==
-  /@babel/plugin-transform-unicode-escapes/7.10.4_@babel+core@7.10.4:
+      integrity: sha512-edJsNzTtvb3MaXQwj8403B7mZoGu9ElDJQZOKjGUnvilquxBA3IQoEIOvkX/1O8xfAsnHS/oQhe2w/IXrr+w0w==
+  /@babel/plugin-transform-unicode-escapes/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
-  /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.10.4:
+  /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
-  /@babel/preset-env/7.10.4_@babel+core@7.10.4:
+  /@babel/preset-env/7.11.0_@babel+core@7.11.0:
     dependencies:
-      '@babel/compat-data': 7.10.4
-      '@babel/core': 7.10.4
-      '@babel/helper-compilation-targets': 7.10.4_@babel+core@7.10.4
+      '@babel/compat-data': 7.11.0
+      '@babel/core': 7.11.0
+      '@babel/helper-compilation-targets': 7.10.4_@babel+core@7.11.0
       '@babel/helper-module-imports': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-proposal-async-generator-functions': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-dynamic-import': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-json-strings': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-numeric-separator': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-object-rest-spread': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-optional-catch-binding': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-optional-chaining': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-private-methods': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-top-level-await': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-arrow-functions': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-async-to-generator': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-block-scoped-functions': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-block-scoping': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-classes': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-computed-properties': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-destructuring': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-duplicate-keys': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-exponentiation-operator': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-for-of': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-function-name': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-literals': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-member-expression-literals': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-modules-amd': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-modules-systemjs': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-modules-umd': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-new-target': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-object-super': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-parameters': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-property-literals': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-regenerator': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-reserved-words': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-shorthand-properties': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-spread': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-sticky-regex': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-template-literals': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-typeof-symbol': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-unicode-escapes': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-unicode-regex': 7.10.4_@babel+core@7.10.4
-      '@babel/preset-modules': 0.1.3_@babel+core@7.10.4
-      '@babel/types': 7.10.4
-      browserslist: 4.12.2
+      '@babel/plugin-proposal-async-generator-functions': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-dynamic-import': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-export-namespace-from': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-json-strings': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-logical-assignment-operators': 7.11.0_@babel+core@7.11.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-numeric-separator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-object-rest-spread': 7.11.0_@babel+core@7.11.0
+      '@babel/plugin-proposal-optional-catch-binding': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-optional-chaining': 7.11.0_@babel+core@7.11.0
+      '@babel/plugin-proposal-private-methods': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-top-level-await': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-arrow-functions': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-async-to-generator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-block-scoped-functions': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-block-scoping': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-classes': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-computed-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-destructuring': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-duplicate-keys': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-exponentiation-operator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-for-of': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-function-name': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-literals': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-member-expression-literals': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-modules-amd': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-modules-systemjs': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-modules-umd': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-new-target': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-object-super': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-property-literals': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-regenerator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-reserved-words': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-shorthand-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-spread': 7.11.0_@babel+core@7.11.0
+      '@babel/plugin-transform-sticky-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-template-literals': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-typeof-symbol': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-unicode-escapes': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-unicode-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/preset-modules': 0.1.3_@babel+core@7.11.0
+      '@babel/types': 7.11.0
+      browserslist: 4.13.0
       core-js-compat: 3.6.5
       invariant: 2.2.4
       levenary: 1.1.1
@@ -1057,73 +1096,66 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==
-  /@babel/preset-modules/0.1.3_@babel+core@7.10.4:
+      integrity: sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==
+  /@babel/preset-modules/0.1.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.10.4
-      '@babel/types': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/types': 7.11.0
       esutils: 2.0.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
-  /@babel/preset-typescript/7.10.4_@babel+core@7.10.4:
+  /@babel/preset-typescript/7.10.4_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-transform-typescript': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-typescript': 7.11.0_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-SdYnvGPv+bLlwkF2VkJnaX/ni1sMNetcGI1+nThF1gyv6Ph8Qucc4ZZAjM5yZcE/AKRXIOTZz7eSRDWOEjPyRQ==
-  /@babel/runtime-corejs3/7.10.4:
+  /@babel/runtime/7.11.0:
     dependencies:
-      core-js-pure: 3.6.5
-      regenerator-runtime: 0.13.5
+      regenerator-runtime: 0.13.7
     dev: true
     resolution:
-      integrity: sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==
-  /@babel/runtime/7.10.4:
-    dependencies:
-      regenerator-runtime: 0.13.5
-    dev: true
-    resolution:
-      integrity: sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
+      integrity: sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==
   /@babel/template/7.10.4:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/parser': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
-  /@babel/traverse/7.10.4:
+  /@babel/traverse/7.11.0:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/generator': 7.10.4
+      '@babel/generator': 7.11.0
       '@babel/helper-function-name': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
-      '@babel/parser': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
       debug: 4.1.1
       globals: 11.12.0
-      lodash: 4.17.15
+      lodash: 4.17.19
     dev: true
     resolution:
-      integrity: sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==
-  /@babel/types/7.10.4:
+      integrity: sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==
+  /@babel/types/7.11.0:
     dependencies:
       '@babel/helper-validator-identifier': 7.10.4
-      lodash: 4.17.15
+      lodash: 4.17.19
       to-fast-properties: 2.0.0
     dev: true
     resolution:
-      integrity: sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
+      integrity: sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
   /@bcoe/v8-coverage/0.2.3:
     dev: true
     resolution:
@@ -1138,12 +1170,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==
-  /@hapi/address/4.0.1:
+  /@hapi/address/4.1.0:
     dependencies:
       '@hapi/hoek': 9.0.4
     dev: false
     resolution:
-      integrity: sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==
+      integrity: sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==
   /@hapi/boom/9.1.0:
     dependencies:
       '@hapi/hoek': 9.0.4
@@ -1161,11 +1193,12 @@ packages:
       integrity: sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==
   /@hapi/joi/17.1.1:
     dependencies:
-      '@hapi/address': 4.0.1
+      '@hapi/address': 4.1.0
       '@hapi/formula': 2.0.0
       '@hapi/hoek': 9.0.4
       '@hapi/pinpoint': 2.0.0
       '@hapi/topo': 5.0.0
+    deprecated: 'joi is leaving the @hapi organization and moving back to ''joi'' (https://github.com/sideway/joi/issues/2411)'
     dev: false
     resolution:
       integrity: sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==
@@ -1197,42 +1230,44 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
-  /@jest/console/26.1.0:
+  /@jest/console/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       chalk: 4.1.0
-      jest-message-util: 26.1.0
-      jest-util: 26.1.0
+      jest-message-util: 26.2.0
+      jest-util: 26.2.0
       slash: 3.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==
-  /@jest/core/26.1.0:
+      integrity: sha512-mXQfx3nSLwiHm1i7jbu+uvi+vvpVjNGzIQYLCfsat9rapC+MJkS4zBseNrgJE0vU921b3P67bQzhduphjY3Tig==
+  /@jest/core/26.2.2:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/reporters': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/reporters': 26.2.2
+      '@jest/test-result': 26.2.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       ansi-escapes: 4.3.1
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.4
-      jest-changed-files: 26.1.0
-      jest-config: 26.1.0
-      jest-haste-map: 26.1.0
-      jest-message-util: 26.1.0
+      jest-changed-files: 26.2.0
+      jest-config: 26.2.2
+      jest-haste-map: 26.2.2
+      jest-message-util: 26.2.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-resolve-dependencies: 26.1.0
-      jest-runner: 26.1.0
-      jest-runtime: 26.1.0
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
-      jest-watcher: 26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve-dependencies: 26.2.2
+      jest-runner: 26.2.2
+      jest-runtime: 26.2.2
+      jest-snapshot: 26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
+      jest-watcher: 26.2.0
       micromatch: 4.0.2
       p-each-series: 2.1.0
       rimraf: 3.0.2
@@ -1242,46 +1277,48 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==
-  /@jest/environment/26.1.0:
+      integrity: sha512-UwA8gNI8aeV4FHGfGAUfO/DHjrFVvlBravF1Tm9Kt6qFE+6YHR47kFhgdepOFpADEKstyO+MVdPvkV6/dyt9sA==
+  /@jest/environment/26.2.0:
     dependencies:
-      '@jest/fake-timers': 26.1.0
-      '@jest/types': 26.1.0
-      jest-mock: 26.1.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
+      jest-mock: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==
-  /@jest/fake-timers/26.1.0:
+      integrity: sha512-oCgp9NmEiJ5rbq9VI/v/yYLDpladAAVvFxZgNsnJxOETuzPZ0ZcKKHYjKYwCtPOP1WCrM5nmyuOhMStXFGHn+g==
+  /@jest/fake-timers/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       '@sinonjs/fake-timers': 6.0.1
-      jest-message-util: 26.1.0
-      jest-mock: 26.1.0
-      jest-util: 26.1.0
+      '@types/node': 14.0.27
+      jest-message-util: 26.2.0
+      jest-mock: 26.2.0
+      jest-util: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==
-  /@jest/globals/26.1.0:
+      integrity: sha512-45Gfe7YzYTKqTayBrEdAF0qYyAsNRBzfkV0IyVUm3cx7AsCWlnjilBM4T40w7IXT5VspOgMPikQlV0M6gHwy/g==
+  /@jest/globals/26.2.0:
     dependencies:
-      '@jest/environment': 26.1.0
-      '@jest/types': 26.1.0
-      expect: 26.1.0
+      '@jest/environment': 26.2.0
+      '@jest/types': 26.2.0
+      expect: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-MKiHPNaT+ZoG85oMaYUmGHEqu98y3WO2yeIDJrs2sJqHhYOy3Z6F7F/luzFomRQ8SQ1wEkmahFAz2291Iv8EAw==
-  /@jest/reporters/26.1.0:
+      integrity: sha512-Hoc6ScEIPaym7RNytIL2ILSUWIGKlwEv+JNFof9dGYOdvPjb2evEURSslvCMkNuNg1ECEClTE8PH7ULlMJntYA==
+  /@jest/reporters/26.2.2:
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/test-result': 26.2.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -1292,10 +1329,10 @@ packages:
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
-      jest-haste-map: 26.1.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-util: 26.1.0
-      jest-worker: 26.1.0
+      jest-haste-map: 26.2.2
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-util: 26.2.0
+      jest-worker: 26.2.1
       slash: 3.0.0
       source-map: 0.6.1
       string-length: 4.0.1
@@ -1305,9 +1342,9 @@ packages:
     engines:
       node: '>= 10.14.2'
     optionalDependencies:
-      node-notifier: 7.0.1
+      node-notifier: 7.0.2
     resolution:
-      integrity: sha512-SVAysur9FOIojJbF4wLP0TybmqwDkdnFxHSPzHMMIYyBtldCW9gG+Q5xWjpMFyErDiwlRuPyMSJSU64A67Pazg==
+      integrity: sha512-7854GPbdFTAorWVh+RNHyPO9waRIN6TcvCezKVxI1khvFq9YjINTW7J3WU+tbR038Ynn6WjYred6vtT0YmIWVQ==
   /@jest/source-map/26.1.0:
     dependencies:
       callsites: 3.1.0
@@ -1318,41 +1355,41 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==
-  /@jest/test-result/26.1.0:
+  /@jest/test-result/26.2.0:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/types': 26.2.0
       '@types/istanbul-lib-coverage': 2.0.3
       collect-v8-coverage: 1.0.1
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==
-  /@jest/test-sequencer/26.1.0:
+      integrity: sha512-kgPlmcVafpmfyQEu36HClK+CWI6wIaAWDHNxfQtGuKsgoa2uQAYdlxjMDBEa3CvI40+2U3v36gQF6oZBkoKatw==
+  /@jest/test-sequencer/26.2.2:
     dependencies:
-      '@jest/test-result': 26.1.0
+      '@jest/test-result': 26.2.0
       graceful-fs: 4.2.4
-      jest-haste-map: 26.1.0
-      jest-runner: 26.1.0
-      jest-runtime: 26.1.0
+      jest-haste-map: 26.2.2
+      jest-runner: 26.2.2
+      jest-runtime: 26.2.2
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==
-  /@jest/transform/26.1.0:
+      integrity: sha512-SliZWon5LNqV/lVXkeowSU6L8++FGOu3f43T01L1Gv6wnFDP00ER0utV9jyK9dVNdXqfMNCN66sfcyar/o7BNw==
+  /@jest/transform/26.2.2:
     dependencies:
-      '@babel/core': 7.10.4
-      '@jest/types': 26.1.0
+      '@babel/core': 7.11.0
+      '@jest/types': 26.2.0
       babel-plugin-istanbul: 6.0.0
       chalk: 4.1.0
       convert-source-map: 1.7.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.4
-      jest-haste-map: 26.1.0
+      jest-haste-map: 26.2.2
       jest-regex-util: 26.0.0
-      jest-util: 26.1.0
+      jest-util: 26.2.0
       micromatch: 4.0.2
       pirates: 4.0.1
       slash: 3.0.0
@@ -1362,7 +1399,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==
+      integrity: sha512-c1snhvi5wRVre1XyoO3Eef5SEWpuBCH/cEbntBUd9tI5sNYiBDmO0My/lc5IuuGYKp/HFIHV1eZpSx5yjdkhKw==
   /@jest/types/25.5.0:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
@@ -1374,30 +1411,31 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  /@jest/types/26.1.0:
+  /@jest/types/26.2.0:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 1.1.2
+      '@types/node': 14.0.27
       '@types/yargs': 15.0.5
       chalk: 4.1.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==
+      integrity: sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==
   /@polka/url/1.0.0-next.11:
     dev: false
     resolution:
       integrity: sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
-  /@sinonjs/commons/1.8.0:
+  /@sinonjs/commons/1.8.1:
     dependencies:
       type-detect: 4.0.8
     dev: true
     resolution:
-      integrity: sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==
+      integrity: sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
   /@sinonjs/fake-timers/6.0.1:
     dependencies:
-      '@sinonjs/commons': 1.8.0
+      '@sinonjs/commons': 1.8.1
     dev: true
     resolution:
       integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
@@ -1425,33 +1463,33 @@ packages:
       integrity: sha512-P8wuK4/7F9SKZruLbB5s/Hak8SPTipQJQ5c4CnQwbRJde2ESE+av84mymmbvxRZTaGYDCXY4sczP/kT5D4TgzQ==
   /@types/babel__core/7.1.9:
     dependencies:
-      '@babel/parser': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
       '@types/babel__generator': 7.6.1
       '@types/babel__template': 7.0.2
-      '@types/babel__traverse': 7.0.12
+      '@types/babel__traverse': 7.0.13
     dev: true
     resolution:
       integrity: sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==
   /@types/babel__generator/7.6.1:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
   /@types/babel__template/7.0.2:
     dependencies:
-      '@babel/parser': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
-  /@types/babel__traverse/7.0.12:
+  /@types/babel__traverse/7.0.13:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
     dev: true
     resolution:
-      integrity: sha512-t4CoEokHTfcyfb4hUaF9oOHu9RmmNWnm1CP0YmMqOOfClKascOmvlEM736vlqeScuGvBDsHkf8R2INd4DWreQA==
+      integrity: sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==
   /@types/color-name/1.1.1:
     dev: true
     resolution:
@@ -1470,20 +1508,20 @@ packages:
       integrity: sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
   /@types/graceful-fs/4.1.3:
     dependencies:
-      '@types/node': 14.0.14
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
-  /@types/hapi__joi/17.1.3:
+  /@types/hapi__joi/17.1.4:
     dev: true
     resolution:
-      integrity: sha512-3+EUJ+haX1Ix/Lmn//qGE0l3dll7TouN+ukkorTroShhyQniOECd30psoxSUjcVE6vVjaS07mqhRkJ6lUZrrbw==
-  /@types/ioredis/4.17.0:
+      integrity: sha512-gqY3TeTyZvnyNhM02HgyCIoGIWsTFMnuzMfnD8evTsr1KIfueGJaz+QC77j+dFvhZ5cJArUNjDRHUjPxNohzGA==
+  /@types/ioredis/4.17.3:
     dependencies:
-      '@types/node': 14.0.14
+      '@types/node': 14.0.27
     dev: true
     resolution:
-      integrity: sha512-2wmT+lB9JAHSYlBrmJGeYDQ4cGlIgxmaC3Bv85LJws/G/OkoFoxPezhMqtTp0JMCgsMadIoI9c43QvRz8WKLSw==
+      integrity: sha512-G0pN/WZb7OBMFksZOBcqATBUeBII00IZ7C9OW0bm7VG3XMXBI75stTXWLBxm6iNLQxdjFZgzThRbc3gBXBhZGw==
   /@types/istanbul-lib-coverage/2.0.3:
     dev: true
     resolution:
@@ -1501,39 +1539,39 @@ packages:
     dev: true
     resolution:
       integrity: sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
-  /@types/jest/26.0.3:
+  /@types/jest/26.0.8:
     dependencies:
       jest-diff: 25.5.0
       pretty-format: 25.5.0
     dev: true
     resolution:
-      integrity: sha512-v89ga1clpVL/Y1+YI0eIu1VMW+KU7Xl8PhylVtDKVWaSUHBHYPLXMQGBdrpHewaKoTvlXkksbYqPgz8b4cmRZg==
+      integrity: sha512-eo3VX9jGASSuv680D4VQ89UmuLZneNxv2MCZjfwlInav05zXVJTzfc//lavdV0GPwSxsXJTy2jALscB7Acqg0g==
   /@types/json-schema/7.0.5:
     dev: true
     resolution:
       integrity: sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
   /@types/jsonwebtoken/8.5.0:
     dependencies:
-      '@types/node': 14.0.14
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==
-  /@types/lodash/4.14.157:
+  /@types/lodash/4.14.158:
     dev: true
     resolution:
-      integrity: sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==
-  /@types/node/14.0.14:
+      integrity: sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==
+  /@types/node/14.0.27:
     dev: true
     resolution:
-      integrity: sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==
+      integrity: sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
   /@types/normalize-package-data/2.4.0:
     dev: true
     resolution:
       integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
-  /@types/prettier/2.0.1:
+  /@types/prettier/2.0.2:
     dev: true
     resolution:
-      integrity: sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==
+      integrity: sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==
   /@types/stack-utils/1.0.1:
     dev: true
     resolution:
@@ -1541,7 +1579,7 @@ packages:
   /@types/superagent/4.1.8:
     dependencies:
       '@types/cookiejar': 2.1.1
-      '@types/node': 14.0.14
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-iol9KxQ7SLHatBJUiZ4uABrS4VS1frLjqPednxZz82eoCzo3Uy3TOH0p0ZIBbfBj8E/xqOtvizjBs9h7xi/l2g==
@@ -1565,12 +1603,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
-  /@typescript-eslint/eslint-plugin/3.5.0_3cfcbecb75673e79af5489ac2f3ac848:
+  /@typescript-eslint/eslint-plugin/3.7.1_d22ed00097c81894d28d3f9848aea27e:
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.5.0_eslint@7.4.0
-      '@typescript-eslint/parser': 3.5.0_eslint@7.4.0
+      '@typescript-eslint/experimental-utils': 3.7.1_eslint@7.6.0
+      '@typescript-eslint/parser': 3.7.1_eslint@7.6.0
       debug: 4.1.1
-      eslint: 7.4.0
+      eslint: 7.6.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.1.0
       semver: 7.3.2
@@ -1586,13 +1624,13 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-m4erZ8AkSjoIUOf8s4k2V1xdL2c1Vy0D3dN6/jC9d7+nEqjY3gxXCkgi3gW/GAxPaA4hV8biaCoTVdQmfAeTCQ==
-  /@typescript-eslint/experimental-utils/3.5.0_eslint@7.4.0:
+      integrity: sha512-3DB9JDYkMrc8Au00rGFiJLK2Ja9CoMP6Ut0sHsXp3ZtSugjNxvSSHTnKLfo4o+QmjYBJqEznDqsG1zj4F2xnsg==
+  /@typescript-eslint/experimental-utils/3.7.1_eslint@7.6.0:
     dependencies:
       '@types/json-schema': 7.0.5
-      '@typescript-eslint/types': 3.5.0
-      '@typescript-eslint/typescript-estree': 3.5.0
-      eslint: 7.4.0
+      '@typescript-eslint/types': 3.7.1
+      '@typescript-eslint/typescript-estree': 3.7.1
+      eslint: 7.6.0
       eslint-scope: 5.1.0
       eslint-utils: 2.1.0
     dev: true
@@ -1601,14 +1639,14 @@ packages:
     peerDependencies:
       eslint: '*'
     resolution:
-      integrity: sha512-zGNOrVi5Wz0jcjUnFZ6QUD0MCox5hBuVwemGCew2qJzUX5xPoyR+0EzS5qD5qQXL/vnQ8Eu+nv03tpeFRwLrDg==
-  /@typescript-eslint/parser/3.5.0_eslint@7.4.0:
+      integrity: sha512-TqE97pv7HrqWcGJbLbZt1v59tcqsSVpWTOf1AqrWK7n8nok2sGgVtYRuGXeNeLw3wXlLEbY1MKP3saB2HsO/Ng==
+  /@typescript-eslint/parser/3.7.1_eslint@7.6.0:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 3.5.0_eslint@7.4.0
-      '@typescript-eslint/types': 3.5.0
-      '@typescript-eslint/typescript-estree': 3.5.0
-      eslint: 7.4.0
+      '@typescript-eslint/experimental-utils': 3.7.1_eslint@7.6.0
+      '@typescript-eslint/types': 3.7.1
+      '@typescript-eslint/typescript-estree': 3.7.1
+      eslint: 7.6.0
       eslint-visitor-keys: 1.3.0
     dev: true
     engines:
@@ -1620,21 +1658,21 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-sU07VbYB70WZHtgOjH/qfAp1+OwaWgrvD1Km1VXqRpcVxt971PMTU7gJtlrCje0M+Sdz7xKAbtiyIu+Y6QdnVA==
-  /@typescript-eslint/types/3.5.0:
+      integrity: sha512-W4QV/gXvfIsccN8225784LNOorcm7ch68Fi3V4Wg7gmkWSQRKevO4RrRqWo6N/Z/myK1QAiGgeaXN57m+R/8iQ==
+  /@typescript-eslint/types/3.7.1:
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
-      integrity: sha512-Dreqb5idi66VVs1QkbAwVeDmdJG+sDtofJtKwKCZXIaBsINuCN7Jv5eDIHrS0hFMMiOvPH9UuOs4splW0iZe4Q==
-  /@typescript-eslint/typescript-estree/3.5.0:
+      integrity: sha512-PZe8twm5Z4b61jt7GAQDor6KiMhgPgf4XmUb9zdrwTbgtC/Sj29gXP1dws9yEn4+aJeyXrjsD9XN7AWFhmnUfg==
+  /@typescript-eslint/typescript-estree/3.7.1:
     dependencies:
-      '@typescript-eslint/types': 3.5.0
-      '@typescript-eslint/visitor-keys': 3.5.0
+      '@typescript-eslint/types': 3.7.1
+      '@typescript-eslint/visitor-keys': 3.7.1
       debug: 4.1.1
       glob: 7.1.6
       is-glob: 4.0.1
-      lodash: 4.17.15
+      lodash: 4.17.19
       semver: 7.3.2
       tsutils: 3.17.1
     dev: true
@@ -1646,19 +1684,19 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-Na71ezI6QP5WVR4EHxwcBJgYiD+Sre9BZO5iJK2QhrmRPo/42+b0no/HZIrdD1sjghzlYv7t+7Jis05M1uMxQg==
-  /@typescript-eslint/visitor-keys/3.5.0:
+      integrity: sha512-m97vNZkI08dunYOr2lVZOHoyfpqRs0KDpd6qkGaIcLGhQ2WPtgHOd/eVbsJZ0VYCQvupKrObAGTOvk3tfpybYA==
+  /@typescript-eslint/visitor-keys/3.7.1:
     dependencies:
       eslint-visitor-keys: 1.3.0
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
-      integrity: sha512-7cTp9rcX2sz9Z+zua9MCOX4cqp5rYyFD5o8LlbSpXrMTXoRdngTtotRZEkm8+FNMHPWYFhitFK+qt/brK8BVJQ==
-  /abab/2.0.3:
+      integrity: sha512-xn22sQbEya+Utj2IqJHGLA3i1jDzR43RzWupxojbSWnj3nnPLavaQmWe5utw03CwYao3r00qzXfgJMGNkrzrAA==
+  /abab/2.0.4:
     dev: true
     resolution:
-      integrity: sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
+      integrity: sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==
   /acorn-globals/6.0.0:
     dependencies:
       acorn: 7.3.1
@@ -1687,7 +1725,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
-  /ajv/6.12.2:
+  /ajv/6.12.3:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -1695,7 +1733,7 @@ packages:
       uri-js: 4.2.2
     dev: true
     resolution:
-      integrity: sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+      integrity: sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
   /amqplib/0.5.6:
     dependencies:
       bitsyntax: 0.1.0
@@ -1840,14 +1878,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
-  /babel-jest/26.1.0_@babel+core@7.10.4:
+  /babel-jest/26.2.2_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@babel/core': 7.11.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
       '@types/babel__core': 7.1.9
       babel-plugin-istanbul: 6.0.0
-      babel-preset-jest: 26.1.0_@babel+core@7.10.4
+      babel-preset-jest: 26.2.0_@babel+core@7.11.0
       chalk: 4.1.0
       graceful-fs: 4.2.4
       slash: 3.0.0
@@ -1857,7 +1895,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-Nkqgtfe7j6PxLO6TnCQQlkMm8wdTdnIF8xrdpooHCuD5hXRzVEPbPneTJKknH5Dsv3L8ip9unHDAp48YQ54Dkg==
+      integrity: sha512-JmLuePHgA+DSOdOL8lPxCgD2LhPPm+rdw1vnxR73PpIrnmKCS2/aBhtkAcxQWuUcW2hBrH8MJ3LKXE7aWpNZyA==
   /babel-plugin-dynamic-import-node/2.3.3:
     dependencies:
       object.assign: 4.1.0
@@ -1876,54 +1914,54 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
-  /babel-plugin-jest-hoist/26.1.0:
+  /babel-plugin-jest-hoist/26.2.0:
     dependencies:
       '@babel/template': 7.10.4
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
       '@types/babel__core': 7.1.9
-      '@types/babel__traverse': 7.0.12
+      '@types/babel__traverse': 7.0.13
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-qhqLVkkSlqmC83bdMhM8WW4Z9tB+JkjqAqlbbohS9sJLT5Ha2vfzuKqg5yenXrAjOPG2YC0WiXdH3a9PvB+YYw==
+      integrity: sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==
   /babel-plugin-transform-typescript-metadata/0.3.0:
     dependencies:
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     resolution:
       integrity: sha512-ASYrM+bxtpfgZKsAOqQfjmLlekIDigRnNCfQBDOOdaqL18hLhZIsbdiHsuaNDTkljlqnbV/DlufaWY55jC2PBg==
-  /babel-preset-current-node-syntax/0.1.3_@babel+core@7.10.4:
+  /babel-preset-current-node-syntax/0.1.3_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.10.4
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.10.4
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==
-  /babel-preset-jest/26.1.0_@babel+core@7.10.4:
+  /babel-preset-jest/26.2.0_@babel+core@7.11.0:
     dependencies:
-      '@babel/core': 7.10.4
-      babel-plugin-jest-hoist: 26.1.0
-      babel-preset-current-node-syntax: 0.1.3_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      babel-plugin-jest-hoist: 26.2.0
+      babel-preset-current-node-syntax: 0.1.3_@babel+core@7.11.0
     dev: true
     engines:
       node: '>= 10.14.2'
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-na9qCqFksknlEj5iSdw1ehMVR06LCCTkZLGKeEtxDDdhg8xpUF09m29Kvh1pRbZ07h7AQ5ttLYUwpXL4tO6w7w==
+      integrity: sha512-R1k8kdP3R9phYQugXeNnK/nvCGlBzG4m3EoIIukC80GXb6wCv2XiwPhK6K9MAkQcMszWBYvl2Wm+yigyXFQqXg==
   /balanced-match/1.0.0:
     dev: true
     resolution:
@@ -1996,18 +2034,18 @@ packages:
     dev: true
     resolution:
       integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
-  /browserslist/4.12.2:
+  /browserslist/4.13.0:
     dependencies:
-      caniuse-lite: 1.0.30001093
-      electron-to-chromium: 1.3.488
-      escalade: 3.0.1
-      node-releases: 1.1.58
+      caniuse-lite: 1.0.30001109
+      electron-to-chromium: 1.3.516
+      escalade: 3.0.2
+      node-releases: 1.1.60
     dev: true
     engines:
       node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
     hasBin: true
     resolution:
-      integrity: sha512-MfZaeYqR8StRZdstAK9hCKDd2StvePCYp5rHzQCPicUjfFliDgmuaBNPHYUTpAywBN8+Wc/d7NYVFkO0aqaBUw==
+      integrity: sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==
   /bser/2.1.1:
     dependencies:
       node-int64: 0.4.0
@@ -2059,10 +2097,10 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
-  /caniuse-lite/1.0.30001093:
+  /caniuse-lite/1.0.30001109:
     dev: true
     resolution:
-      integrity: sha512-0+ODNoOjtWD5eS9aaIpf4K0gQqZfILNY4WSNuYzeT1sXni+lMrrVjc0odEobJt6wrODofDZUX8XYi/5y7+xl8g==
+      integrity: sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ==
   /capture-exit/2.0.0:
     dependencies:
       rsvp: 4.8.5
@@ -2225,16 +2263,11 @@ packages:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
   /core-js-compat/3.6.5:
     dependencies:
-      browserslist: 4.12.2
+      browserslist: 4.13.0
       semver: 7.0.0
     dev: true
     resolution:
       integrity: sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==
-  /core-js-pure/3.6.5:
-    dev: true
-    requiresBuild: true
-    resolution:
-      integrity: sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
   /core-util-is/1.0.2:
     resolution:
       integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -2286,7 +2319,7 @@ packages:
       integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   /data-urls/2.0.0:
     dependencies:
-      abab: 2.0.3
+      abab: 2.0.4
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.1.0
     dev: true
@@ -2316,14 +2349,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
-  /decamelize/3.2.0:
-    dependencies:
-      xregexp: 4.3.0
-    dev: true
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==
   /decimal.js/10.2.0:
     dev: true
     resolution:
@@ -2435,10 +2460,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
-  /electron-to-chromium/1.3.488:
+  /electron-to-chromium/1.3.516:
     dev: true
     resolution:
-      integrity: sha512-NReBdOugu1yl8ly+0VDtiQ6Yw/1sLjnvflWq0gvY1nfUXU2PbA+1XAVuEb7ModnwL/MfUPjby7e4pAFnSHiy6Q==
+      integrity: sha512-WDM5AAQdOrvLqSX8g3Zd5AujBXfMxf96oeZkff0U2HF5op3tjShE+on2yay3r1UD4M9I3p0iHpAS4+yV8U8A9A==
+  /emittery/0.7.1:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==
   /emoji-regex/7.0.3:
     dev: true
     resolution:
@@ -2477,12 +2508,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /escalade/3.0.1:
+  /escalade/3.0.2:
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==
+      integrity: sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
   /escape-string-regexp/1.0.5:
     dev: true
     engines:
@@ -2521,9 +2552,9 @@ packages:
     dev: true
     resolution:
       integrity: sha512-AMzafaVJmNfbjJZyJY9ap1LU/QWjvZtCwbsVkqn0ye/gJqGPcU1w7FCIJiUzPaFYneNpKaQzYt/VbLXNv9ym5g==
-  /eslint-config-prettier/6.11.0_eslint@7.4.0:
+  /eslint-config-prettier/6.11.0_eslint@7.6.0:
     dependencies:
-      eslint: 7.4.0
+      eslint: 7.6.0
       get-stdin: 6.0.0
     dev: true
     hasBin: true
@@ -2531,9 +2562,9 @@ packages:
       eslint: '>=3.14.1'
     resolution:
       integrity: sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
-  /eslint-plugin-prettier/3.1.4_eslint@7.4.0+prettier@2.0.5:
+  /eslint-plugin-prettier/3.1.4_eslint@7.6.0+prettier@2.0.5:
     dependencies:
-      eslint: 7.4.0
+      eslint: 7.6.0
       prettier: 2.0.5
       prettier-linter-helpers: 1.0.0
     dev: true
@@ -2567,10 +2598,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
-  /eslint/7.4.0:
+  /eslint/7.6.0:
     dependencies:
       '@babel/code-frame': 7.10.4
-      ajv: 6.12.2
+      ajv: 6.12.3
       chalk: 4.1.0
       cross-spawn: 7.0.3
       debug: 4.1.1
@@ -2579,7 +2610,7 @@ packages:
       eslint-scope: 5.1.0
       eslint-utils: 2.1.0
       eslint-visitor-keys: 1.3.0
-      espree: 7.1.0
+      espree: 7.2.0
       esquery: 1.3.1
       esutils: 2.0.3
       file-entry-cache: 5.0.1
@@ -2593,7 +2624,7 @@ packages:
       js-yaml: 3.14.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
-      lodash: 4.17.15
+      lodash: 4.17.19
       minimatch: 3.0.4
       natural-compare: 1.4.0
       optionator: 0.9.1
@@ -2601,7 +2632,7 @@ packages:
       regexpp: 3.1.0
       semver: 7.3.2
       strip-ansi: 6.0.0
-      strip-json-comments: 3.1.0
+      strip-json-comments: 3.1.1
       table: 5.4.6
       text-table: 0.2.0
       v8-compile-cache: 2.1.1
@@ -2610,8 +2641,8 @@ packages:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
     resolution:
-      integrity: sha512-gU+lxhlPHu45H3JkEGgYhWhkR9wLHHEXC9FbWFnTlEkbKyZKWgWRLgf61E8zWmBuI6g5xKBph9ltg3NtZMVF8g==
-  /espree/7.1.0:
+      integrity: sha512-QlAManNtqr7sozWm5TF4wIH9gmUm2hE3vNRUvyoYAa4y1l5/jxD/PQStEjBMQtCqZmSep8UxrcecI60hOpe61w==
+  /espree/7.2.0:
     dependencies:
       acorn: 7.3.1
       acorn-jsx: 5.2.0_acorn@7.3.1
@@ -2620,7 +2651,7 @@ packages:
     engines:
       node: ^10.12.0 || >=12.0.0
     resolution:
-      integrity: sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==
+      integrity: sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==
   /esprima/4.0.1:
     dev: true
     engines:
@@ -2680,7 +2711,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
-  /execa/4.0.2:
+  /execa/4.0.3:
     dependencies:
       cross-spawn: 7.0.3
       get-stream: 5.1.0
@@ -2688,14 +2719,14 @@ packages:
       is-stream: 2.0.0
       merge-stream: 2.0.0
       npm-run-path: 4.0.1
-      onetime: 5.1.0
+      onetime: 5.1.1
       signal-exit: 3.0.3
       strip-final-newline: 2.0.0
     dev: true
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==
+      integrity: sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==
   /exit/0.1.2:
     dev: true
     engines:
@@ -2716,19 +2747,19 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
-  /expect/26.1.0:
+  /expect/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       ansi-styles: 4.2.1
       jest-get-type: 26.0.0
-      jest-matcher-utils: 26.1.0
-      jest-message-util: 26.1.0
+      jest-matcher-utils: 26.2.0
+      jest-message-util: 26.2.0
       jest-regex-util: 26.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==
+      integrity: sha512-8AMBQ9UVcoUXt0B7v+5/U5H6yiUR87L6eKCfjE3spx7Ya5lF+ebUo37MCFBML2OiLfkX1sxmQOZhIDonyVTkcw==
   /extend-shallow/2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -3006,15 +3037,16 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-  /har-validator/5.1.3:
+  /har-validator/5.1.5:
     dependencies:
-      ajv: 6.12.2
+      ajv: 6.12.3
       har-schema: 2.0.0
+    deprecated: this library is no longer supported
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+      integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   /has-flag/3.0.0:
     dev: true
     engines:
@@ -3391,7 +3423,7 @@ packages:
       integrity: sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
-      '@babel/core': 7.10.4
+      '@babel/core': 7.11.0
       '@istanbuljs/schema': 0.1.2
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -3429,62 +3461,62 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
-  /jest-changed-files/26.1.0:
+  /jest-changed-files/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
-      execa: 4.0.2
+      '@jest/types': 26.2.0
+      execa: 4.0.3
       throat: 5.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-HS5MIJp3B8t0NRKGMCZkcDUZo36mVRvrDETl81aqljT1S9tqiHRSpyoOvWg9ZilzZG9TDisDNaN1IXm54fLRZw==
-  /jest-cli/26.1.0:
+      integrity: sha512-+RyJb+F1K/XBLIYiL449vo5D+CvlHv29QveJUWNPXuUicyZcq+tf1wNxmmFeRvAU1+TzhwqczSjxnCCFt7+8iA==
+  /jest-cli/26.2.2:
     dependencies:
-      '@jest/core': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/core': 26.2.2
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.4
       import-local: 3.0.2
       is-ci: 2.0.0
-      jest-config: 26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
+      jest-config: 26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
       prompts: 2.3.2
-      yargs: 15.4.0
+      yargs: 15.4.1
     dev: true
     engines:
       node: '>= 10.14.2'
     hasBin: true
     resolution:
-      integrity: sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==
-  /jest-config/26.1.0:
+      integrity: sha512-vVcly0n/ijZvdy6gPQiQt0YANwX2hLTPQZHtW7Vi3gcFdKTtif7YpI85F8R8JYy5DFSWz4x1OW0arnxlziu5Lw==
+  /jest-config/26.2.2:
     dependencies:
-      '@babel/core': 7.10.4
-      '@jest/test-sequencer': 26.1.0
-      '@jest/types': 26.1.0
-      babel-jest: 26.1.0_@babel+core@7.10.4
+      '@babel/core': 7.11.0
+      '@jest/test-sequencer': 26.2.2
+      '@jest/types': 26.2.0
+      babel-jest: 26.2.2_@babel+core@7.11.0
       chalk: 4.1.0
       deepmerge: 4.2.2
       glob: 7.1.6
       graceful-fs: 4.2.4
-      jest-environment-jsdom: 26.1.0
-      jest-environment-node: 26.1.0
+      jest-environment-jsdom: 26.2.0
+      jest-environment-node: 26.2.0
       jest-get-type: 26.0.0
-      jest-jasmine2: 26.1.0
+      jest-jasmine2: 26.2.2
       jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
       micromatch: 4.0.2
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==
+      integrity: sha512-2lhxH0y4YFOijMJ65usuf78m7+9/8+hAb1PZQtdRdgnQpAb4zP6KcVDDktpHEkspBKnc2lmFu+RQdHukUUbiTg==
   /jest-diff/25.5.0:
     dependencies:
       chalk: 3.0.0
@@ -3496,17 +3528,17 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
-  /jest-diff/26.1.0:
+  /jest-diff/26.2.0:
     dependencies:
       chalk: 4.1.0
       diff-sequences: 26.0.0
       jest-get-type: 26.0.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==
+      integrity: sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==
   /jest-docblock/26.0.0:
     dependencies:
       detect-newline: 3.1.0
@@ -3515,43 +3547,45 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==
-  /jest-each/26.1.0:
+  /jest-each/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       jest-get-type: 26.0.0
-      jest-util: 26.1.0
-      pretty-format: 26.1.0
+      jest-util: 26.2.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-lYiSo4Igr81q6QRsVQq9LIkJW0hZcKxkIkHzNeTMPENYYDw/W/Raq28iJ0sLlNFYz2qxxeLnc5K2gQoFYlu2bA==
-  /jest-environment-jsdom/26.1.0:
+      integrity: sha512-gHPCaho1twWHB5bpcfnozlc6mrMi+VAewVPNgmwf81x2Gzr6XO4dl+eOrwPWxbkYlgjgrYjWK2xgKnixbzH3Ew==
+  /jest-environment-jsdom/26.2.0:
     dependencies:
-      '@jest/environment': 26.1.0
-      '@jest/fake-timers': 26.1.0
-      '@jest/types': 26.1.0
-      jest-mock: 26.1.0
-      jest-util: 26.1.0
-      jsdom: 16.2.2
+      '@jest/environment': 26.2.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
+      jest-mock: 26.2.0
+      jest-util: 26.2.0
+      jsdom: 16.3.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==
-  /jest-environment-node/26.1.0:
+      integrity: sha512-sDG24+5M4NuIGzkI3rJW8XUlrpkvIdE9Zz4jhD8OBnVxAw+Y1jUk9X+lAOD48nlfUTlnt3lbAI3k2Ox+WF3S0g==
+  /jest-environment-node/26.2.0:
     dependencies:
-      '@jest/environment': 26.1.0
-      '@jest/fake-timers': 26.1.0
-      '@jest/types': 26.1.0
-      jest-mock: 26.1.0
-      jest-util: 26.1.0
+      '@jest/environment': 26.2.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
+      jest-mock: 26.2.0
+      jest-util: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-DNm5x1aQH0iRAe9UYAkZenuzuJ69VKzDCAYISFHQ5i9e+2Tbeu2ONGY7YStubCLH8a1wdKBgqScYw85+ySxqxg==
+      integrity: sha512-4M5ExTYkJ19efBzkiXtBi74JqKLDciEk4CEsp5tTjWGYMrlKFQFtwIVG3tW1OGE0AlXhZjuHPwubuRYY4j4uOw==
   /jest-get-type/25.2.6:
     dev: true
     engines:
@@ -3564,75 +3598,77 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==
-  /jest-haste-map/26.1.0:
+  /jest-haste-map/26.2.2:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       '@types/graceful-fs': 4.1.3
+      '@types/node': 14.0.27
       anymatch: 3.1.1
       fb-watchman: 2.0.1
       graceful-fs: 4.2.4
-      jest-serializer: 26.1.0
-      jest-util: 26.1.0
-      jest-worker: 26.1.0
+      jest-regex-util: 26.0.0
+      jest-serializer: 26.2.0
+      jest-util: 26.2.0
+      jest-worker: 26.2.1
       micromatch: 4.0.2
       sane: 4.1.0
       walker: 1.0.7
-      which: 2.0.2
     dev: true
     engines:
       node: '>= 10.14.2'
     optionalDependencies:
       fsevents: 2.1.3
     resolution:
-      integrity: sha512-WeBS54xCIz9twzkEdm6+vJBXgRBQfdbbXD0dk8lJh7gLihopABlJmIQFdWSDDtuDe4PRiObsjZSUjbJ1uhWEpA==
-  /jest-jasmine2/26.1.0:
+      integrity: sha512-3sJlMSt+NHnzCB+0KhJ1Ut4zKJBiJOlbrqEYNdRQGlXTv8kqzZWjUKQRY3pkjmlf+7rYjAV++MQ4D6g4DhAyOg==
+  /jest-jasmine2/26.2.2:
     dependencies:
-      '@babel/traverse': 7.10.4
-      '@jest/environment': 26.1.0
+      '@babel/traverse': 7.11.0
+      '@jest/environment': 26.2.0
       '@jest/source-map': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       chalk: 4.1.0
       co: 4.6.0
-      expect: 26.1.0
+      expect: 26.2.0
       is-generator-fn: 2.1.0
-      jest-each: 26.1.0
-      jest-matcher-utils: 26.1.0
-      jest-message-util: 26.1.0
-      jest-runtime: 26.1.0
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      pretty-format: 26.1.0
+      jest-each: 26.2.0
+      jest-matcher-utils: 26.2.0
+      jest-message-util: 26.2.0
+      jest-runtime: 26.2.2
+      jest-snapshot: 26.2.2
+      jest-util: 26.2.0
+      pretty-format: 26.2.0
       throat: 5.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==
-  /jest-leak-detector/26.1.0:
+      integrity: sha512-Q8AAHpbiZMVMy4Hz9j1j1bg2yUmPa1W9StBvcHqRaKa9PHaDUMwds8LwaDyzP/2fkybcTQE4+pTMDOG9826tEw==
+  /jest-leak-detector/26.2.0:
     dependencies:
       jest-get-type: 26.0.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-dsMnKF+4BVOZwvQDlgn3MG+Ns4JuLv8jNvXH56bgqrrboyCbI1rQg6EI5rs+8IYagVcfVP2yZFKfWNZy0rK0Hw==
-  /jest-matcher-utils/26.1.0:
+      integrity: sha512-aQdzTX1YiufkXA1teXZu5xXOJgy7wZQw6OJ0iH5CtQlOETe6gTSocaYKUNui1SzQ91xmqEUZ/WRavg9FD82rtQ==
+  /jest-matcher-utils/26.2.0:
     dependencies:
       chalk: 4.1.0
-      jest-diff: 26.1.0
+      jest-diff: 26.2.0
       jest-get-type: 26.0.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==
-  /jest-message-util/26.1.0:
+      integrity: sha512-2cf/LW2VFb3ayPHrH36ZDjp9+CAeAe/pWBAwsV8t3dKcrINzXPVxq8qMWOxwt5BaeBCx4ZupVGH7VIgB8v66vQ==
+  /jest-message-util/26.2.0:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       '@types/stack-utils': 1.0.1
       chalk: 4.1.0
       graceful-fs: 4.2.4
@@ -3643,18 +3679,19 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==
-  /jest-mock/26.1.0:
+      integrity: sha512-g362RhZaJuqeqG108n1sthz5vNpzTNy926eNDszo4ncRbmmcMRIUAZibnd6s5v2XSBCChAxQtCoN25gnzp7JbQ==
+  /jest-mock/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==
-  /jest-pnp-resolver/1.2.2_jest-resolve@26.1.0:
+      integrity: sha512-XeC7yWtWmWByoyVOHSsE7NYsbXJLtJNgmhD7z4MKumKm6ET0si81bsSLbQ64L5saK3TgsHo2B/UqG5KNZ1Sp/Q==
+  /jest-pnp-resolver/1.2.2_jest-resolve@26.2.2:
     dependencies:
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
     dev: true
     engines:
       node: '>=6'
@@ -3671,23 +3708,23 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
-  /jest-resolve-dependencies/26.1.0:
+  /jest-resolve-dependencies/26.2.2:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       jest-regex-util: 26.0.0
-      jest-snapshot: 26.1.0
+      jest-snapshot: 26.2.2
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-fQVEPHHQ1JjHRDxzlLU/buuQ9om+hqW6Vo928aa4b4yvq4ZHBtRSDsLdKQLuCqn5CkTVpYZ7ARh2fbA8WkRE6g==
-  /jest-resolve/26.1.0_jest-resolve@26.1.0:
+      integrity: sha512-S5vufDmVbQXnpP7435gr710xeBGUFcKNpNswke7RmFvDQtmqPjPVU/rCeMlEU0p6vfpnjhwMYeaVjKZAy5QYJA==
+  /jest-resolve/26.2.2_jest-resolve@26.2.2:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       graceful-fs: 4.2.4
-      jest-pnp-resolver: 1.2.2_jest-resolve@26.1.0
-      jest-util: 26.1.0
+      jest-pnp-resolver: 1.2.2_jest-resolve@26.2.2
+      jest-util: 26.2.0
       read-pkg-up: 7.0.1
       resolve: 1.17.0
       slash: 3.0.0
@@ -3697,100 +3734,103 @@ packages:
     peerDependencies:
       jest-resolve: '*'
     resolution:
-      integrity: sha512-KsY1JV9FeVgEmwIISbZZN83RNGJ1CC+XUCikf/ZWJBX/tO4a4NvA21YixokhdR9UnmPKKAC4LafVixJBrwlmfg==
-  /jest-runner/26.1.0:
+      integrity: sha512-ye9Tj/ILn/0OgFPE/3dGpQPUqt4dHwIocxt5qSBkyzxQD8PbL0bVxBogX2FHxsd3zJA7V2H/cHXnBnNyyT9YoQ==
+  /jest-runner/26.2.2:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/environment': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/environment': 26.2.0
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       chalk: 4.1.0
+      emittery: 0.7.1
       exit: 0.1.2
       graceful-fs: 4.2.4
-      jest-config: 26.1.0
+      jest-config: 26.2.2
       jest-docblock: 26.0.0
-      jest-haste-map: 26.1.0
-      jest-jasmine2: 26.1.0
-      jest-leak-detector: 26.1.0
-      jest-message-util: 26.1.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-runtime: 26.1.0
-      jest-util: 26.1.0
-      jest-worker: 26.1.0
+      jest-haste-map: 26.2.2
+      jest-leak-detector: 26.2.0
+      jest-message-util: 26.2.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-runtime: 26.2.2
+      jest-util: 26.2.0
+      jest-worker: 26.2.1
       source-map-support: 0.5.19
       throat: 5.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==
-  /jest-runtime/26.1.0:
+      integrity: sha512-/qb6ptgX+KQ+aNMohJf1We695kaAfuu3u3ouh66TWfhTpLd9WbqcF6163d/tMoEY8GqPztXPLuyG0rHRVDLxCA==
+  /jest-runtime/26.2.2:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/environment': 26.1.0
-      '@jest/fake-timers': 26.1.0
-      '@jest/globals': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/environment': 26.2.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/globals': 26.2.0
       '@jest/source-map': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/test-result': 26.2.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
       '@types/yargs': 15.0.5
       chalk: 4.1.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.6
       graceful-fs: 4.2.4
-      jest-config: 26.1.0
-      jest-haste-map: 26.1.0
-      jest-message-util: 26.1.0
-      jest-mock: 26.1.0
+      jest-config: 26.2.2
+      jest-haste-map: 26.2.2
+      jest-message-util: 26.2.0
+      jest-mock: 26.2.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-snapshot: 26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
       slash: 3.0.0
       strip-bom: 4.0.0
-      yargs: 15.4.0
+      yargs: 15.4.1
     dev: true
     engines:
       node: '>= 10.14.2'
     hasBin: true
     resolution:
-      integrity: sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==
-  /jest-serializer/26.1.0:
+      integrity: sha512-a8VXM3DxCDnCIdl9+QucWFfQ28KdqmyVFqeKLigHdErtsx56O2ZIdQkhFSuP1XtVrG9nTNHbKxjh5XL1UaFDVQ==
+  /jest-serializer/26.2.0:
     dependencies:
+      '@types/node': 14.0.27
       graceful-fs: 4.2.4
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-eqZOQG/0+MHmr25b2Z86g7+Kzd5dG9dhCiUoyUNJPgiqi38DqbDEOlHcNijyfZoj74soGBohKBZuJFS18YTJ5w==
-  /jest-snapshot/26.1.0:
+      integrity: sha512-V7snZI9IVmyJEu0Qy0inmuXgnMWDtrsbV2p9CRAcmlmPVwpC2ZM8wXyYpiugDQnwLHx0V4+Pnog9Exb3UO8M6Q==
+  /jest-snapshot/26.2.2:
     dependencies:
-      '@babel/types': 7.10.4
-      '@jest/types': 26.1.0
-      '@types/prettier': 2.0.1
+      '@babel/types': 7.11.0
+      '@jest/types': 26.2.0
+      '@types/prettier': 2.0.2
       chalk: 4.1.0
-      expect: 26.1.0
+      expect: 26.2.0
       graceful-fs: 4.2.4
-      jest-diff: 26.1.0
+      jest-diff: 26.2.0
       jest-get-type: 26.0.0
-      jest-haste-map: 26.1.0
-      jest-matcher-utils: 26.1.0
-      jest-message-util: 26.1.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
+      jest-haste-map: 26.2.2
+      jest-matcher-utils: 26.2.0
+      jest-message-util: 26.2.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
       natural-compare: 1.4.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
       semver: 7.3.2
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-YhSbU7eMTVQO/iRbNs8j0mKRxGp4plo7sJ3GzOQ0IYjvsBiwg0T1o0zGQAYepza7lYHuPTrG5J2yDd0CE2YxSw==
-  /jest-util/26.1.0:
+      integrity: sha512-NdjD8aJS7ePu268Wy/n/aR1TUisG0BOY+QOW4f6h46UHEKOgYmmkvJhh2BqdVZQ0BHSxTMt04WpCf9njzx8KtA==
+  /jest-util/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       chalk: 4.1.0
       graceful-fs: 4.2.4
       is-ci: 2.0.0
@@ -3799,53 +3839,55 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==
-  /jest-validate/26.1.0:
+      integrity: sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==
+  /jest-validate/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       camelcase: 6.0.0
       chalk: 4.1.0
       jest-get-type: 26.0.0
       leven: 3.1.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-WPApOOnXsiwhZtmkDsxnpye+XLb/tUISP+H6cHjfUIXvlG+eKwP+isnivsxlHCPaO9Q5wvbhloIBkdF3qUn+Nw==
-  /jest-watcher/26.1.0:
+      integrity: sha512-8XKn3hM6VIVmLNuyzYLCPsRCT83o8jMZYhbieh4dAyKLc4Ypr36rVKC+c8WMpWkfHHpGnEkvWUjjIAyobEIY/Q==
+  /jest-watcher/26.2.0:
     dependencies:
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       ansi-escapes: 4.3.1
       chalk: 4.1.0
-      jest-util: 26.1.0
+      jest-util: 26.2.0
       string-length: 4.0.1
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-ffEOhJl2EvAIki613oPsSG11usqnGUzIiK7MMX6hE4422aXOcVEG3ySCTDFLn1+LZNXGPE8tuJxhp8OBJ1pgzQ==
-  /jest-worker/26.1.0:
+      integrity: sha512-674Boco4Joe0CzgKPL6K4Z9LgyLx+ZvW2GilbpYb8rFEUkmDGgsZdv1Hv5rxsRpb1HLgKUOL/JfbttRCuFdZXQ==
+  /jest-worker/26.2.1:
     dependencies:
+      '@types/node': 14.0.27
       merge-stream: 2.0.0
       supports-color: 7.1.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==
-  /jest/26.1.0:
+      integrity: sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==
+  /jest/26.2.2:
     dependencies:
-      '@jest/core': 26.1.0
+      '@jest/core': 26.2.2
       import-local: 3.0.2
-      jest-cli: 26.1.0
+      jest-cli: 26.2.2
     dev: true
     engines:
       node: '>= 10.14.2'
     hasBin: true
     resolution:
-      integrity: sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==
+      integrity: sha512-EkJNyHiAG1+A8pqSz7cXttoVa34hOEzN/MrnJhYnfp5VHxflVcf2pu3oJSrhiy6LfIutLdWo+n6q63tjcoIeig==
   /js-tokens/4.0.0:
     dev: true
     resolution:
@@ -3862,9 +3904,9 @@ packages:
     dev: true
     resolution:
       integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
-  /jsdom/16.2.2:
+  /jsdom/16.3.0:
     dependencies:
-      abab: 2.0.3
+      abab: 2.0.4
       acorn: 7.3.1
       acorn-globals: 6.0.0
       cssom: 0.4.4
@@ -3878,7 +3920,7 @@ packages:
       nwsapi: 2.2.0
       parse5: 5.1.1
       request: 2.88.2
-      request-promise-native: 1.0.8_request@2.88.2
+      request-promise-native: 1.0.9_request@2.88.2
       saxes: 5.0.1
       symbol-tree: 3.2.4
       tough-cookie: 3.0.1
@@ -3888,7 +3930,7 @@ packages:
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.1.0
-      ws: 7.3.0
+      ws: 7.3.1
       xml-name-validator: 3.0.0
     dev: true
     engines:
@@ -3899,7 +3941,7 @@ packages:
       canvas:
         optional: true
     resolution:
-      integrity: sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==
+      integrity: sha512-zggeX5UuEknpdZzv15+MS1dPYG0J/TftiiNunOeNxSl3qr8Z6cIlQpN0IdJa44z9aFxZRIVqRncvEhQ7X5DtZg==
   /jsesc/0.5.0:
     dev: true
     hasBin: true
@@ -4107,9 +4149,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-  /lodash/4.17.15:
-    resolution:
-      integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
   /lodash/4.17.19:
     resolution:
       integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -4282,22 +4321,22 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-  /node-notifier/7.0.1:
+  /node-notifier/7.0.2:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
       semver: 7.3.2
       shellwords: 0.1.1
-      uuid: 7.0.3
+      uuid: 8.3.0
       which: 2.0.2
     dev: true
     optional: true
     resolution:
-      integrity: sha512-VkzhierE7DBmQEElhTGJIoiZa1oqRijOtgOlsXg32KrJRXsPy0NXFBqWGW/wTswnJlDCs5viRYaqWguqzsKcmg==
-  /node-releases/1.1.58:
+      integrity: sha512-ux+n4hPVETuTL8+daJXTOC6uKLgMsl1RYfFv7DKRzyvzBapqco0rZZ9g72ZN8VS6V+gvNYHYa/ofcCY8fkJWsA==
+  /node-releases/1.1.60:
     dev: true
     resolution:
-      integrity: sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==
+      integrity: sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.8
@@ -4394,14 +4433,14 @@ packages:
     dev: true
     resolution:
       integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
-  /onetime/5.1.0:
+  /onetime/5.1.1:
     dependencies:
       mimic-fn: 2.1.0
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+      integrity: sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==
   /optionator/0.8.3:
     dependencies:
       deep-is: 0.1.3
@@ -4470,7 +4509,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
-  /parse-json/5.0.0:
+  /parse-json/5.0.1:
     dependencies:
       '@babel/code-frame': 7.10.4
       error-ex: 1.3.2
@@ -4480,7 +4519,7 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+      integrity: sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==
   /parse5/5.1.1:
     dev: true
     resolution:
@@ -4601,9 +4640,9 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
-  /pretty-format/26.1.0:
+  /pretty-format/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       ansi-regex: 5.0.0
       ansi-styles: 4.2.1
       react-is: 16.13.1
@@ -4611,7 +4650,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==
+      integrity: sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==
   /process-nextick-args/2.0.1:
     dev: true
     resolution:
@@ -4681,7 +4720,7 @@ packages:
     dependencies:
       '@types/normalize-package-data': 2.4.0
       normalize-package-data: 2.5.0
-      parse-json: 5.0.0
+      parse-json: 5.0.1
       type-fest: 0.6.0
     dev: true
     engines:
@@ -4747,13 +4786,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
-  /regenerator-runtime/0.13.5:
+  /regenerator-runtime/0.13.7:
     dev: true
     resolution:
-      integrity: sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+      integrity: sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
   /regenerator-transform/0.14.5:
     dependencies:
-      '@babel/runtime': 7.10.4
+      '@babel/runtime': 7.11.0
     dev: true
     resolution:
       integrity: sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==
@@ -4818,9 +4857,9 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha1-jcrkcOHIirwtYA//Sndihtp15jc=
-  /request-promise-core/1.1.3_request@2.88.2:
+  /request-promise-core/1.1.4_request@2.88.2:
     dependencies:
-      lodash: 4.17.15
+      lodash: 4.17.19
       request: 2.88.2
     dev: true
     engines:
@@ -4828,20 +4867,21 @@ packages:
     peerDependencies:
       request: ^2.34
     resolution:
-      integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==
-  /request-promise-native/1.0.8_request@2.88.2:
+      integrity: sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
+  /request-promise-native/1.0.9_request@2.88.2:
     dependencies:
       request: 2.88.2
-      request-promise-core: 1.1.3_request@2.88.2
+      request-promise-core: 1.1.4_request@2.88.2
       stealthy-require: 1.1.1
       tough-cookie: 2.5.0
+    deprecated: 'request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142'
     dev: true
     engines:
       node: '>=0.12.0'
     peerDependencies:
       request: ^2.34
     resolution:
-      integrity: sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
+      integrity: sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
   /request/2.88.2:
     dependencies:
       aws-sign2: 0.7.0
@@ -4851,7 +4891,7 @@ packages:
       extend: 3.0.2
       forever-agent: 0.6.1
       form-data: 2.3.3
-      har-validator: 5.1.3
+      har-validator: 5.1.5
       http-signature: 1.2.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
@@ -5295,12 +5335,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
-  /strip-json-comments/3.1.0:
+  /strip-json-comments/3.1.1:
     dev: true
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
+      integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
   /superagent/3.8.3:
     dependencies:
       component-emitter: 1.3.0
@@ -5358,8 +5398,8 @@ packages:
       integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
   /table/5.4.6:
     dependencies:
-      ajv: 6.12.2
-      lodash: 4.17.15
+      ajv: 6.12.3
+      lodash: 4.17.19
       slice-ansi: 2.1.0
       string-width: 3.1.0
     dev: true
@@ -5556,13 +5596,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  /typescript/3.9.6:
-    dev: true
-    engines:
-      node: '>=4.2.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
   /typescript/3.9.7:
     dev: true
     engines:
@@ -5653,12 +5686,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-  /uuid/7.0.3:
+  /uuid/8.3.0:
     dev: true
     hasBin: true
     optional: true
     resolution:
-      integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+      integrity: sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
   /v8-compile-cache/2.1.1:
     dev: true
     resolution:
@@ -5799,7 +5832,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  /ws/7.3.0:
+  /ws/7.3.1:
     dev: true
     engines:
       node: '>=8.3.0'
@@ -5812,7 +5845,7 @@ packages:
       utf-8-validate:
         optional: true
     resolution:
-      integrity: sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
+      integrity: sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
   /xml-name-validator/3.0.0:
     dev: true
     resolution:
@@ -5821,12 +5854,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-  /xregexp/4.3.0:
-    dependencies:
-      '@babel/runtime-corejs3': 7.10.4
-    dev: true
-    resolution:
-      integrity: sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==
   /y18n/4.0.0:
     dev: true
     resolution:
@@ -5840,10 +5867,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
-  /yargs/15.4.0:
+  /yargs/15.4.1:
     dependencies:
       cliui: 6.0.0
-      decamelize: 3.2.0
+      decamelize: 1.2.0
       find-up: 4.1.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
@@ -5857,4 +5884,4 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-D3fRFnZwLWp8jVAAhPZBsmeIHY8tTsb8ItV9KaAaopmC6wde2u6Yw29JBIZHXw14kgkRnYmDgmQU4FVMDlIsWw==
+      integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
     dependencies:
       '@hapi/boom': 9.1.0
       '@hapi/joi': 17.1.1
-      '@spectacles/rest': 0.8.3
+      '@spectacles/brokers': 0.8.0
       '@spectacles/util': 0.4.0
       common-tags: 1.8.0
       ioredis: 4.17.3
@@ -50,6 +50,7 @@ importers:
       postgres: 2.0.0-beta.0
       readdirp: 3.4.0
       reflect-metadata: 0.1.13
+      rest: 'link:../rest'
       tslib: 2.0.0
       tsyringe: 4.3.0
     devDependencies:
@@ -68,7 +69,7 @@ importers:
     specifiers:
       '@hapi/boom': ^9.1.0
       '@hapi/joi': ^17.1.1
-      '@spectacles/rest': ^0.8.3
+      '@spectacles/brokers': ^0.8.0
       '@spectacles/types': ^0.2.1
       '@spectacles/util': ^0.4.0
       '@types/common-tags': ^1.8.0
@@ -87,6 +88,7 @@ importers:
       postgres: ^2.0.0-beta.0
       readdirp: ^3.4.0
       reflect-metadata: ^0.1.13
+      rest: 'link:..\rest'
       rimraf: ^3.0.2
       supertest: ^4.0.2
       tslib: ^2.0.0
@@ -95,11 +97,11 @@ importers:
   packages/handler:
     dependencies:
       '@spectacles/brokers': 0.8.0
-      '@spectacles/rest': 0.8.3
       lexure: 0.8.0
       postgres: 2.0.0-beta.0
       readdirp: 3.4.0
       reflect-metadata: 0.1.13
+      rest: 'link:../rest'
       tslib: 2.0.0
       tsyringe: 4.3.0
     devDependencies:
@@ -110,7 +112,6 @@ importers:
       typescript: 3.9.6
     specifiers:
       '@spectacles/brokers': ^0.8.0
-      '@spectacles/rest': ^0.8.3
       '@spectacles/types': ^0.2.1
       '@types/node': ^14.0.14
       env-cmd: ^10.1.0
@@ -118,6 +119,7 @@ importers:
       postgres: ^2.0.0-beta.0
       readdirp: ^3.4.0
       reflect-metadata: ^0.1.13
+      rest: 'link:..\rest'
       rimraf: ^3.0.2
       tslib: ^2.0.0
       tsyringe: ^4.3.0
@@ -144,6 +146,18 @@ importers:
       rimraf: ^3.0.2
       tslib: ^2.0.0
       typescript: ^3.9.6
+  packages/rest:
+    dependencies:
+      tslib: 2.0.0
+    devDependencies:
+      '@spectacles/brokers': 0.8.0
+      rimraf: 3.0.2
+      typescript: 3.9.7
+    specifiers:
+      '@spectacles/brokers': ^0.8.0
+      rimraf: ^3.0.2
+      tslib: ^2.0.0
+      typescript: ^3.9.7
 lockfileVersion: 5.1
 packages:
   /@babel/code-frame/7.10.4:
@@ -1392,24 +1406,15 @@ packages:
       '@spectacles/util': 0.3.2
       amqplib: 0.5.6
       ioredis: 4.17.3
-      lodash: 4.17.15
+      lodash: 4.17.19
       ulid: 2.3.0
-    dev: false
     resolution:
       integrity: sha512-UGZWdNRcvsp7SqZtZPf15sXJxm0WZIChh0bzll9Wt+S93QFJClnNl6L1iH1M/fAfW7ynJ51uWHvVMcGrlACrDQ==
-  /@spectacles/rest/0.8.3:
-    dependencies:
-      form-data: 2.5.1
-      node-fetch: 2.6.0
-    dev: false
-    resolution:
-      integrity: sha512-nwXtkg8bNrwYfqdaTdPx41eQgQwGz0hTM/VtYZMa0YsWm9DItP1g8qBpS3PM6GBR9tAiwdQaOtoRgXOOYC5Fgw==
   /@spectacles/types/0.2.1:
     dev: true
     resolution:
       integrity: sha512-dIcqyPiUvVlYhQdWVqPCod1O5ZAWVZjavja2ZoECrq43F4BtgBZKFnBSHYIIC3jQrVXV486Nhl47vEQNiud6+g==
   /@spectacles/util/0.3.2:
-    dev: false
     peerDependencies:
       erlpack: 'github:discordapp/erlpack'
     resolution:
@@ -1699,7 +1704,6 @@ packages:
       readable-stream: 1.1.14
       safe-buffer: 5.1.2
       url-parse: 1.4.7
-    dev: false
     engines:
       node: '>=0.8 <=12'
     resolution:
@@ -1818,6 +1822,7 @@ packages:
     resolution:
       integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
   /asynckit/0.4.0:
+    dev: true
     resolution:
       integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=
   /atob/2.1.2:
@@ -1948,13 +1953,11 @@ packages:
       buffer-more-ints: 1.0.0
       debug: 2.6.9
       safe-buffer: 5.1.2
-    dev: false
     engines:
       node: '>=0.8'
     resolution:
       integrity: sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==
   /bluebird/3.7.2:
-    dev: false
     resolution:
       integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
   /brace-expansion/1.1.11:
@@ -2020,7 +2023,6 @@ packages:
     resolution:
       integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
   /buffer-more-ints/1.0.0:
-    dev: false
     resolution:
       integrity: sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
   /cache-base/1.0.1:
@@ -2131,7 +2133,6 @@ packages:
     resolution:
       integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
   /cluster-key-slot/1.1.0:
-    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -2181,6 +2182,7 @@ packages:
   /combined-stream/1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+    dev: true
     engines:
       node: '>= 0.8'
     resolution:
@@ -2376,12 +2378,12 @@ packages:
     resolution:
       integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
   /delayed-stream/1.0.0:
+    dev: true
     engines:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
   /denque/1.4.1:
-    dev: false
     engines:
       node: '>=0.10'
     resolution:
@@ -2866,6 +2868,7 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.27
+    dev: true
     engines:
       node: '>= 0.12'
     resolution:
@@ -3164,7 +3167,6 @@ packages:
       redis-errors: 1.2.0
       redis-parser: 3.0.0
       standard-as-callback: 2.0.1
-    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -3353,7 +3355,6 @@ packages:
     resolution:
       integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   /isarray/0.0.1:
-    dev: false
     resolution:
       integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
   /isarray/1.0.0:
@@ -4069,11 +4070,9 @@ packages:
     resolution:
       integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   /lodash.defaults/4.2.0:
-    dev: false
     resolution:
       integrity: sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
   /lodash.flatten/4.4.0:
-    dev: false
     resolution:
       integrity: sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
   /lodash.includes/4.3.0:
@@ -4111,6 +4110,9 @@ packages:
   /lodash/4.17.15:
     resolution:
       integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  /lodash/4.17.19:
+    resolution:
+      integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
   /loose-envify/1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -4186,6 +4188,7 @@ packages:
     resolution:
       integrity: sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
   /mime-db/1.44.0:
+    dev: true
     engines:
       node: '>= 0.6'
     resolution:
@@ -4193,6 +4196,7 @@ packages:
   /mime-types/2.1.27:
     dependencies:
       mime-db: 1.44.0
+    dev: true
     engines:
       node: '>= 0.6'
     resolution:
@@ -4268,12 +4272,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-  /node-fetch/2.6.0:
-    dev: false
-    engines:
-      node: 4.x || >=6.0.0
-    resolution:
-      integrity: sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
   /node-int64/0.4.0:
     dev: true
     resolution:
@@ -4663,7 +4661,6 @@ packages:
     resolution:
       integrity: sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
   /querystringify/2.1.1:
-    dev: false
     resolution:
       integrity: sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
   /react-is/16.13.1:
@@ -4697,7 +4694,6 @@ packages:
       inherits: 2.0.4
       isarray: 0.0.1
       string_decoder: 0.10.31
-    dev: false
     resolution:
       integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
   /readable-stream/2.3.7:
@@ -4721,11 +4717,9 @@ packages:
     resolution:
       integrity: sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
   /redis-commands/1.5.0:
-    dev: false
     resolution:
       integrity: sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==
   /redis-errors/1.2.0:
-    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -4733,7 +4727,6 @@ packages:
   /redis-parser/3.0.0:
     dependencies:
       redis-errors: 1.2.0
-    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -4888,7 +4881,6 @@ packages:
     resolution:
       integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
   /requires-port/1.0.0:
-    dev: false
     resolution:
       integrity: sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
   /resolve-cwd/3.0.0:
@@ -5214,7 +5206,6 @@ packages:
     resolution:
       integrity: sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==
   /standard-as-callback/2.0.1:
-    dev: false
     resolution:
       integrity: sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
   /static-extend/0.1.2:
@@ -5262,7 +5253,6 @@ packages:
     resolution:
       integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
   /string_decoder/0.10.31:
-    dev: false
     resolution:
       integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
   /string_decoder/1.1.1:
@@ -5573,8 +5563,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+  /typescript/3.9.7:
+    dev: true
+    engines:
+      node: '>=4.2.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
   /ulid/2.3.0:
-    dev: false
     hasBin: true
     resolution:
       integrity: sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==
@@ -5640,7 +5636,6 @@ packages:
     dependencies:
       querystringify: 2.1.1
       requires-port: 1.0.0
-    dev: false
     resolution:
       integrity: sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
   /use/3.1.1:


### PR DESCRIPTION
- Removes spectacles/rest in favor of spectacles/proxy
- Some minor fixes
  - Resolved issues with `pnpm` not being executable after installation using `npx`
  - Fixed errors with Hasura configuration and optional migrations
  - Fixed port binding conflict between API and Grafana by re-binding the API to port 4000