### PR TITLE
chore: add simple launch script for Windows

### DIFF
--- a/y.ps1
+++ b/y.ps1
@@ -1,0 +1,3 @@
+$env = $args[0]
+$cmd = $args | Select-Object -Skip 1
+docker-compose -f docker-compose.yml -f docker-compose.$env.yml $cmd


### PR DESCRIPTION
Makes launching the bot easier. `.\y [env] [...docker command]`: for example, `.\y local up --build`.