### PR TITLE
feat(handler): embed utils

### DIFF
--- a/src/handler/Constants.ts
+++ b/src/handler/Constants.ts
@@ -1,0 +1,7 @@
+export const EMBED_TITLE_LIMIT = 256;
+export const EMBED_DESCRIPTION_LIMIT = 2048;
+export const EMBED_FOOTER_TEXT_LIMIT = 2048;
+export const EMBED_AUTHOR_NAME_LIMIT = 256;
+export const EMBED_FIELD_LIMIT = 25;
+export const EMBED_FIELD_NAME_LIMIT = 256;
+export const EMBED_FIELD_VALUE_LIMIT = 1024;

--- a/src/handler/util/index.test.ts
+++ b/src/handler/util/index.test.ts
@@ -24,7 +24,7 @@ describe('ellipsis', () => {
 	});
 
 	test('text longer than total', () => {
-		expect(ellipsis(text, 7)).toBe('lorem i');
+		expect(ellipsis(text, 7)).toBe('lore...');
 	});
 });
 
@@ -43,7 +43,7 @@ describe('addField', () => {
 			fields: [
 				{
 					name: 'foo',
-					value: 'foobar',
+					value: 'bar',
 				},
 			],
 		};

--- a/src/handler/util/index.test.ts
+++ b/src/handler/util/index.test.ts
@@ -1,0 +1,132 @@
+import { ellipsis, truncateEmbed, addField } from '.';
+import {
+	EMBED_AUTHOR_NAME_LIMIT,
+	EMBED_DESCRIPTION_LIMIT,
+	EMBED_FIELD_LIMIT,
+	EMBED_FIELD_NAME_LIMIT,
+	EMBED_FIELD_VALUE_LIMIT,
+	EMBED_FOOTER_TEXT_LIMIT,
+	EMBED_TITLE_LIMIT,
+} from '../Constants';
+
+describe('ellipsis', () => {
+	const text = 'lorem ipsum';
+	test('text shorter than total', () => {
+		expect(ellipsis(text, 20)).toBe(text);
+	});
+	test('text longer than total and total < 4', () => {
+		expect(ellipsis(text, 0)).toBe('');
+		expect(ellipsis(text, 1)).toBe('l');
+		expect(ellipsis(text, 2)).toBe('lo');
+		expect(ellipsis(text, 3)).toBe('lor');
+	});
+	test('text longer than total', () => {
+		expect(ellipsis(text, 7)).toBe('lorem i');
+	});
+});
+
+describe('addField', () => {
+	test('no fields', () => {
+		const embed = {};
+		const added = addField(embed, { name: 'foo', value: 'bar' });
+		expect(added.fields.length).toBe(1);
+		const addedField = added.fields[0];
+		expect(addedField.name).toBe('foo');
+		expect(addedField.value).toBe('bar');
+	});
+
+	test('has fields', () => {
+		const embed = {
+			fields: [
+				{
+					name: 'foo',
+					value: 'foobar',
+				},
+			],
+		};
+		const added = addField(embed, { name: 'newFieldName', value: 'newFieldValue' });
+		expect(added.fields.length).toBe(2);
+		const oldField = added.fields[0];
+		const newField = added.fields[1];
+		expect(oldField.name).toBe('foo');
+		expect(oldField.value).toBe('bar');
+		expect(newField.name).toBe('newFieldName');
+		expect(newField.value).toBe('newFieldValue');
+	});
+});
+
+describe('truncateEmbed', () => {
+	test('truncate description', () => {
+		const embed = {
+			description: 'a'.repeat(EMBED_DESCRIPTION_LIMIT + 1),
+		};
+		expect(truncateEmbed(embed).description.length).toBeLessThanOrEqual(EMBED_DESCRIPTION_LIMIT);
+	});
+
+	test('truncate title', () => {
+		const embed = {
+			title: 'a'.repeat(EMBED_TITLE_LIMIT + 1),
+		};
+		expect(truncateEmbed(embed).title.length).toBeLessThanOrEqual(EMBED_TITLE_LIMIT);
+	});
+
+	test('truncate author name', () => {
+		const embed = {
+			author: {
+				name: 'a'.repeat(EMBED_AUTHOR_NAME_LIMIT + 1),
+				icon_url: 'foo.bar.jpg',
+				url: 'foo.bar',
+			},
+			description: 'foo bar',
+		};
+		const truncated = truncateEmbed(embed);
+		expect(truncated.author.name.length).toBeLessThanOrEqual(EMBED_AUTHOR_NAME_LIMIT);
+		expect(truncated.author.icon_url).toBe(embed.author.icon_url);
+		expect(truncated.author.url).toBe(embed.author.url);
+		expect(truncated.description).toBe(embed.description);
+	});
+
+	test('truncate footer text', () => {
+		const embed = {
+			footer: {
+				text: 'a'.repeat(EMBED_FOOTER_TEXT_LIMIT + 1),
+				icon_url: 'foo.bar.jpg',
+			},
+			description: 'foo bar',
+		};
+		const truncated = truncateEmbed(embed);
+		expect(truncated.footer.text.length).toBeLessThanOrEqual(EMBED_FOOTER_TEXT_LIMIT);
+		expect(truncated.footer.icon_url).toBe(embed.footer.icon_url);
+		expect(truncated.description).toBe(embed.description);
+	});
+
+	test('truncate field value and name', () => {
+		const embed = {
+			fields: [
+				{
+					name: 'a'.repeat(EMBED_FIELD_NAME_LIMIT + 1),
+					value: 'b'.repeat(EMBED_FIELD_VALUE_LIMIT + 1),
+				},
+			],
+		};
+		const truncated = truncateEmbed(embed);
+		const truncField = truncated.fields[0];
+		expect(truncField.name.length).toBeLessThanOrEqual(EMBED_FIELD_NAME_LIMIT);
+		expect(truncField.value.length).toBeLessThanOrEqual(EMBED_FIELD_VALUE_LIMIT);
+	});
+
+	test('truncate fields', () => {
+		const field = {
+			name: 'foo',
+			value: 'bar',
+		};
+		const fields = new Array(EMBED_FIELD_LIMIT + 1).fill(field);
+		const embed = {
+			fields,
+			description: 'foo bar',
+		};
+		const truncated = truncateEmbed(embed);
+		expect(truncated.fields.length).toBeLessThanOrEqual(EMBED_FIELD_LIMIT);
+		expect(truncated.description).toBe(embed.description);
+	});
+});

--- a/src/handler/util/index.test.ts
+++ b/src/handler/util/index.test.ts
@@ -11,15 +11,18 @@ import {
 
 describe('ellipsis', () => {
 	const text = 'lorem ipsum';
+
 	test('text shorter than total', () => {
 		expect(ellipsis(text, 20)).toBe(text);
 	});
+
 	test('text longer than total and total < 4', () => {
 		expect(ellipsis(text, 0)).toBe('');
 		expect(ellipsis(text, 1)).toBe('l');
 		expect(ellipsis(text, 2)).toBe('lo');
 		expect(ellipsis(text, 3)).toBe('lor');
 	});
+
 	test('text longer than total', () => {
 		expect(ellipsis(text, 7)).toBe('lorem i');
 	});

--- a/src/handler/util/index.ts
+++ b/src/handler/util/index.ts
@@ -1,0 +1,57 @@
+import { Embed, EmbedField } from '@spectacles/types';
+import {
+	EMBED_AUTHOR_NAME_LIMIT,
+	EMBED_DESCRIPTION_LIMIT,
+	EMBED_FIELD_LIMIT,
+	EMBED_FIELD_NAME_LIMIT,
+	EMBED_FIELD_VALUE_LIMIT,
+	EMBED_FOOTER_TEXT_LIMIT,
+	EMBED_TITLE_LIMIT,
+} from '../Constants';
+
+export function addField(embed: Embed, data: EmbedField): Embed {
+	return {
+		...embed,
+		fields: [...(embed.fields ?? []), data],
+	};
+}
+
+export function ellipsis(text: string, total: number): string {
+	if (text.length <= total) {
+		return text;
+	}
+	const keep = total - 3;
+	if (keep < 1) {
+		return text.slice(0, total);
+	}
+	return `${text.slice(0, keep)}...`;
+}
+
+export function truncateEmbed(embed: Embed): Embed {
+	return {
+		description: embed.description ? ellipsis(embed.description, EMBED_DESCRIPTION_LIMIT) : null,
+		title: embed.title ? ellipsis(embed.title, EMBED_TITLE_LIMIT) : null,
+		author: embed.author
+			? {
+					...embed.author,
+					name: ellipsis(embed.author.name, EMBED_AUTHOR_NAME_LIMIT),
+			  }
+			: null,
+		footer: embed.footer
+			? {
+					...embed.footer,
+					text: ellipsis(embed.footer.text, EMBED_FOOTER_TEXT_LIMIT),
+			  }
+			: null,
+		fields: embed.fields
+			? embed.fields
+					.map((field) => {
+						return {
+							name: ellipsis(field.name, EMBED_FIELD_NAME_LIMIT),
+							value: ellipsis(field.value, EMBED_FIELD_VALUE_LIMIT),
+						};
+					})
+					.slice(0, EMBED_FIELD_LIMIT)
+			: [],
+	};
+}


### PR DESCRIPTION
Add embed utilities for handler

* ellipsis: truncate string input with `...` if applicable
* addField: immutably add a field to the provided embed structure
* truncateEmbed: truncate embed attributes as appropriate

`truncateEmbed` is especially useful to construct embeds from external api responses as well as i18n input. Instead of having to truncate each attribute and apply the logic in each command this centralizes the logic into a tested utility function and allows a single call before sending the embed, resulting in much cleaner command code, where applicable.

**caveat**: in case of upstream API changes constants need to be adapted.