### PR TITLE
fix(handler): proper handling of embed types in truncate

### DIFF
--- a/src/handler/util/index.test.ts
+++ b/src/handler/util/index.test.ts
@@ -89,6 +89,18 @@ describe('truncateEmbed', () => {
 		expect(truncated.description).toBe(embed.description);
 	});
 
+	test('truncate description, author no name', () => {
+		const embed = {
+			author: {
+				icon_url: 'foo.bar.jpg',
+				url: 'foo.bar',
+			},
+			description: 'a'.repeat(EMBED_DESCRIPTION_LIMIT + 1),
+		};
+		expect(truncateEmbed(embed).description.length).toBeLessThanOrEqual(EMBED_DESCRIPTION_LIMIT);
+		expect(truncateEmbed(embed).author.name).toBe(undefined);
+	});
+
 	test('truncate footer text', () => {
 		const embed = {
 			footer: {

--- a/src/handler/util/index.test.ts
+++ b/src/handler/util/index.test.ts
@@ -144,4 +144,37 @@ describe('truncateEmbed', () => {
 		expect(truncated.fields.length).toBeLessThanOrEqual(EMBED_FIELD_LIMIT);
 		expect(truncated.description).toBe(embed.description);
 	});
+
+	test('no properties missing', () => {
+		const embed = {
+			author: {
+				icon_url: 'icon_url',
+				name: 'name',
+				url: 'url',
+			},
+			color: 1,
+			description: 'description',
+			fields: [
+				{
+					name: 'name',
+					value: 'value',
+				},
+			],
+			footer: {
+				text: 'name',
+				icon_url: 'icon_url',
+			},
+			image: {
+				url: 'url',
+			},
+			thumbnail: {
+				url: 'url',
+			},
+			timestamp: 'timestamp',
+			url: 'url',
+			title: 'title',
+		};
+
+		expect(truncateEmbed(embed)).toMatchObject(embed);
+	});
 });

--- a/src/handler/util/index.ts
+++ b/src/handler/util/index.ts
@@ -29,20 +29,20 @@ export function ellipsis(text: string, total: number): string {
 
 export function truncateEmbed(embed: Embed): Embed {
 	return {
-		description: embed.description ? ellipsis(embed.description, EMBED_DESCRIPTION_LIMIT) : null,
-		title: embed.title ? ellipsis(embed.title, EMBED_TITLE_LIMIT) : null,
+		description: embed.description ? ellipsis(embed.description, EMBED_DESCRIPTION_LIMIT) : undefined,
+		title: embed.title ? ellipsis(embed.title, EMBED_TITLE_LIMIT) : undefined,
 		author: embed.author
 			? {
 					...embed.author,
-					name: ellipsis(embed.author.name, EMBED_AUTHOR_NAME_LIMIT),
+					name: embed.author.name ? ellipsis(embed.author.name, EMBED_AUTHOR_NAME_LIMIT) : undefined,
 			  }
-			: null,
+			: undefined,
 		footer: embed.footer
 			? {
 					...embed.footer,
 					text: ellipsis(embed.footer.text, EMBED_FOOTER_TEXT_LIMIT),
 			  }
-			: null,
+			: undefined,
 		fields: embed.fields
 			? embed.fields
 					.map((field) => {

--- a/src/handler/util/index.ts
+++ b/src/handler/util/index.ts
@@ -29,6 +29,7 @@ export function ellipsis(text: string, total: number): string {
 
 export function truncateEmbed(embed: Embed): Embed {
 	return {
+		...embed,
 		description: embed.description ? ellipsis(embed.description, EMBED_DESCRIPTION_LIMIT) : undefined,
 		title: embed.title ? ellipsis(embed.title, EMBED_TITLE_LIMIT) : undefined,
 		author: embed.author


### PR DESCRIPTION
The truncate handling introduced in #768 is not correct type-wise and prevents building the project if used.  This PR aims to fix this by introducing the correct defaulting mechanism to `undefined` instead of `null`. Additionally embed authors do not necessarily have a name, which was not handled properly before.