### PR TITLE
feat(handler): regex commands

### DIFF
--- a/src/handler/bin/index.ts
+++ b/src/handler/bin/index.ts
@@ -4,7 +4,7 @@ import { Amqp } from '@spectacles/brokers';
 import { AmqpResponseOptions } from '@spectacles/brokers/typings/src/Amqp';
 import { on } from 'events';
 import postgres from 'postgres';
-import { Lexer, Parser, prefixedStrategy, Args } from 'lexure';
+import { Lexer, Parser, prefixedStrategy, Args, Token, ParserOutput } from 'lexure';
 import { resolve } from 'path';
 import readdirp from 'readdirp';
 import Rest from '@yuudachi/rest';
@@ -14,7 +14,7 @@ import i18next from 'i18next';
 import HttApi, { BackendOptions } from 'i18next-http-backend';
 import { decode, encode } from '@msgpack/msgpack';
 
-import Command, { commandInfo } from '../src/Command';
+import Command, { commandInfo, ExecutionContext } from '../src/Command';
 import { kSQL } from '../src/tokens';
 
 const token = process.env.DISCORD_TOKEN;
@@ -102,7 +102,7 @@ void (async () => {
 			const command = commands.get(cmd.value);
 			if (command) {
 				try {
-					await command.execute(message, new Args(out), locale);
+					await command.execute(message, new Args(out), locale, ExecutionContext['PREFIXED']);
 				} catch (error) {
 					void rest.post(`/channels/${message.channel_id}/messages`, { content: error.message });
 				}
@@ -111,25 +111,26 @@ void (async () => {
 			}
 		}
 
-		{
-			const lexer = new Lexer(message.content).setQuotes(quotes);
-			const tokens = lexer.lex();
-			const parser = new Parser(tokens).setUnorderedStrategy(prefixedStrategy(flagPrefixes, optionSeparators));
-			const out = parser.parse();
+		for (const command of commands.values()) {
+			if (!command.regExp) continue;
+			const match = command.regExp.exec(message.content);
+			if (!match) continue;
 
-			for (const command of commands.values()) {
-				if (!command.regExp) continue;
-				const match = command.regExp.exec(message.content);
-				if (!match) continue;
+			const [, ...args] = match;
+			const tokens: Token[] = args.map((s) => ({ raw: s, trailing: '', value: s }));
+			const out: ParserOutput = {
+				ordered: tokens,
+				flags: new Set(),
+				options: new Map(),
+			};
 
-				try {
-					await command.execute(message, new Args(out), locale, { regexMatch: match });
-				} catch (error) {
-					void rest.post(`/channels/${message.channel_id}/messages`, { content: error.message });
-				}
-
-				break;
+			try {
+				await command.execute(message, new Args(out), locale, ExecutionContext['REGEXP']);
+			} catch (error) {
+				void rest.post(`/channels/${message.channel_id}/messages`, { content: error.message });
 			}
+
+			break;
 		}
 
 		continue;

--- a/src/handler/src/Command.ts
+++ b/src/handler/src/Command.ts
@@ -14,7 +14,7 @@ export default interface Command {
 }
 
 export enum ExecutionContext {
-	PREFIXED = 0,
+	PREFIXED,
 	REGEXP,
 }
 

--- a/src/handler/src/Command.ts
+++ b/src/handler/src/Command.ts
@@ -10,11 +10,12 @@ export default interface Command {
 	clientPermissions?: string[];
 	userPermissions?: string[];
 	regExp?: RegExp;
-	execute(message: Message, args: Args, locale: string, information?: CommandAdditions): unknown | Promise<unknown>;
+	execute(message: Message, args: Args, locale: string, executionContext: ExecutionContext): unknown | Promise<unknown>;
 }
 
-export interface CommandAdditions {
-	regexMatches?: RegExpExecArray;
+export enum ExecutionContext {
+	PREFIXED = 0,
+	REGEXP,
 }
 
 export interface CommandInfo {

--- a/src/handler/src/Command.ts
+++ b/src/handler/src/Command.ts
@@ -9,7 +9,12 @@ export default interface Command {
 	description?: string;
 	clientPermissions?: string[];
 	userPermissions?: string[];
-	execute(message: Message, args: Args, locale: string): unknown | Promise<unknown>;
+	regExp?: RegExp;
+	execute(message: Message, args: Args, locale: string, information?: CommandAdditions): unknown | Promise<unknown>;
+}
+
+export interface CommandAdditions {
+	regexMatches?: RegExpExecArray;
 }
 
 export interface CommandInfo {


### PR DESCRIPTION
This PR aims to introduce the ability for commands to be executed via regular expressions.

- Command: new optional regExp property which can hold a regular expression, the command can be triggered with. The positional args are retrieved from the capture groups
- Command#execute has a new argument with the execution context (enum, so far prefixed and regexp, other - like web - are thinkable) allowing for context-aware execution of commands (silent fails on regex commands to not disturb conversations if args are only later found to be unusable for this command, due to accidental matching.
- Command: consumes the Args instance as it would with other commands, flags and options are omitted, UX seems to suffer once one introduces flags into pattern commands that can execute on any position in the message body
- Command parsing: slight restructure to allow attempting to execute via regex should no prefix or command name match be found
- After the first matching pattern no further patterns will be tested

<details>
<summary>first idea (revisited after discussion below)</summary>

To facilitate this re-arranging command parsing and adding to the Command interface was required:

- **Command** | Command has a new (optional) regExp property which can hold a regular expression the command can be triggered with
- **Command** | Command#execute has a new (optional) argument with the capability to provide additional information in special circumstances (an interface rather than a single value was chosen to make this concept easily extendable should need arise). This is used with regular expression commands to provide the match, preventing the need to re-do the matching and giving information about the special circumstance (will be a non-null RegExpExecArray if executes through a regular expression)
- **Parsing** | Allow further checks if no matching command is found
- **Parsing** | Re-parse the message content without a prefix to be able to still provide a valid Args instance and not drop flags, should they be required for the command.
- **Parsing** | If any command is found no regular expressions will be checked
- **Parsing** | After the first matching expression no further expressions are checked

</details>