### PR TITLE
feat(handler): allow optional match groups

### DIFF
--- a/src/handler/bin/index.ts
+++ b/src/handler/bin/index.ts
@@ -113,7 +113,7 @@ void (async () => {
 			if (!match) continue;
 
 			const [, ...args] = match;
-			const tokens: Token[] = args.map((s) => ({ raw: s, trailing: '', value: s }));
+			const tokens: Token[] = args.filter((v) => v).map((s) => ({ raw: s, trailing: '', value: s }));
 			const out: ParserOutput = {
 				ordered: tokens,
 				flags: new Set(),


### PR DESCRIPTION
This PR filters out non-matching optional match groups during RegExp execution of commands, allowing for optional regex arguments and more variable matching patterns.

Example:
- `owner/repository#issue`
- `alias#issue`
