### PR TITLE
fix(logs): only provide information if available

### DIFF
--- a/src/bot/listeners/client/memberLog/guildMemberAdd.ts
+++ b/src/bot/listeners/client/memberLog/guildMemberAdd.ts
@@ -2,7 +2,6 @@ import { Listener } from 'discord-akairo';
 import { GuildMember, MessageEmbed, TextChannel } from 'discord.js';
 import { SETTINGS, MAX_TRUST_ACCOUNT_AGE } from '../../../util/constants';
 import * as moment from 'moment';
-import { stripIndents } from 'common-tags';
 
 function colorFromDuration(duration: number) {
 	const percent = Math.min(duration / (MAX_TRUST_ACCOUNT_AGE / 100), 100);
@@ -48,22 +47,16 @@ export default class GuildMemberAddMemberLogListener extends Listener {
 				.setFooter('User joined')
 				.setTimestamp(new Date());
 
+			const parts = [];
+
 			if (memberlog.MENTION) {
-				embed.setDescription(
-					stripIndents`
-						• Profile: ${member}
-						• Created: ${sinceCreationFormatted} (${creationFormatted})
-						• Joined: ${joinFormatted}
-					`,
-				);
-			} else {
-				embed.setDescription(
-					stripIndents`
-						• Created: ${sinceCreationFormatted} (${creationFormatted})
-						• Joined: ${joinFormatted}
-					`,
-				);
+				parts.push(`• Profile: ${member}`);
 			}
+
+			parts.push(`• Created: ${sinceCreationFormatted} (${creationFormatted})`);
+			parts.push(`• Joined: ${joinFormatted}`);
+
+			embed.setDescription(parts.join('\n'));
 
 			return (this.client.channels.cache.get(memberlog.ID) as TextChannel).send(embed);
 		}

--- a/src/bot/listeners/client/memberLog/guildMemberRemove.ts
+++ b/src/bot/listeners/client/memberLog/guildMemberRemove.ts
@@ -2,7 +2,6 @@ import { Listener } from 'discord-akairo';
 import { GuildMember, MessageEmbed, TextChannel } from 'discord.js';
 import { COLORS, SETTINGS } from '../../../util/constants';
 import * as moment from 'moment';
-import { stripIndents } from 'common-tags';
 
 export default class GuildMemberRemoveMemberLogListener extends Listener {
 	public constructor() {
@@ -25,22 +24,19 @@ export default class GuildMemberRemoveMemberLogListener extends Listener {
 				.setFooter('User left')
 				.setTimestamp(new Date());
 
+			const parts = [];
+
 			if (memberlog.MENTION) {
-				embed.setDescription(
-					stripIndents`
-						• Profile: ${member}
-						• Joined: ${sinceJoinFormatted} (${joinFormatted})
-						• Left: ${leaveFormatted}
-					`,
-				);
-			} else {
-				embed.setDescription(
-					stripIndents`
-						• Joined: ${sinceJoinFormatted} (${joinFormatted})
-						• Left: ${leaveFormatted}
-					`,
-				);
+				parts.push(`• Profile: ${member}`);
 			}
+
+			if (member.joinedTimestamp) {
+				parts.push(`• Joined: ${sinceJoinFormatted} (${joinFormatted})`);
+			}
+
+			parts.push(`• Left: ${leaveFormatted}`);
+
+			embed.setDescription(parts.join('\n'));
 
 			return (this.client.channels.cache.get(memberlog.ID) as TextChannel).send(embed);
 		}


### PR DESCRIPTION
- #joinedAt and #joinedTimestamp are nullable because discord actually just provides a User object and guild id on GUILD_MEMBER_REMOVE
- should the member be uncached discord.js creates a GuildMember instance from this resulting in unwanted behavior
- this PR fixes this by just providing information if it is actually available
- since the underlying User object will always be valid there is no need to apply the same checks for user properties like the account creation date