### PR TITLE
feat: add antiraid functionality

### DIFF
--- a/src/bot/commands/mod/antiraid.ts
+++ b/src/bot/commands/mod/antiraid.ts
@@ -1,0 +1,62 @@
+import ms from '@naval-base/ms';
+import { Command } from 'discord-akairo';
+import { Message, Permissions } from 'discord.js';
+import { MESSAGES, SETTINGS } from '../../util/constants';
+
+export default class AntiraidCommand extends Command {
+	public constructor() {
+		super('antiraid', {
+			aliases: ['antiraid'],
+			category: 'mod',
+			description: {
+				content: MESSAGES.COMMANDS.MOD.ANTIRAID.DESCRIPTION,
+				usage: '<kick|ban> <age> | <disable>',
+				examples: ['kick 10h', 'ban 1w', 'disable'],
+			},
+			channel: 'guild',
+			clientPermissions: [Permissions.FLAGS.BAN_MEMBERS, Permissions.FLAGS.KICK_MEMBERS],
+			userPermissions: [Permissions.FLAGS.MANAGE_GUILD],
+			ratelimit: 2,
+			args: [
+				{
+					id: 'action',
+					type: (_, str): string | null => {
+						str = str.toLowerCase();
+						return ['kick', 'ban', 'disable'].includes(str) ? str : null;
+					},
+					prompt: {
+						start: (message: Message) => MESSAGES.COMMANDS.MOD.ANTIRAID.PROMPT.START(message.author),
+						retry: (message: Message) => MESSAGES.COMMANDS.MOD.ANTIRAID.PROMPT.RETRY(message.author),
+					},
+				},
+				{
+					id: 'age',
+					type: (_, str): number | null => {
+						if (!str) return null;
+						const duration = ms(str);
+						if (!isNaN(duration)) return duration;
+						return null;
+					},
+				},
+			],
+		});
+	}
+
+	public async exec(message: Message, { action, age }: { action: string; age: number }) {
+		if (action === 'disable') {
+			this.client.settings.delete(message.guild!, SETTINGS.ANTIRAID_MODE);
+			this.client.settings.delete(message.guild!, SETTINGS.ANTIRAID_AGE);
+
+			return message.util?.send(MESSAGES.COMMANDS.MOD.ANTIRAID.DISABLED);
+		}
+
+		if (!age) {
+			return message.util?.send(MESSAGES.COMMANDS.MOD.ANTIRAID.NO_AGE);
+		}
+
+		this.client.settings.set(message.guild!, SETTINGS.ANTIRAID_MODE, action.toUpperCase());
+		this.client.settings.set(message.guild!, SETTINGS.ANTIRAID_AGE, age);
+
+		return message.util?.send(MESSAGES.COMMANDS.MOD.ANTIRAID.ENABLED(action, ms(age, true)));
+	}
+}

--- a/src/bot/listeners/client/moderation/guildMemberAdd.ts
+++ b/src/bot/listeners/client/moderation/guildMemberAdd.ts
@@ -47,7 +47,7 @@ export default class GuildMemberAddAntiraidListener extends Listener {
 			caseId: totalCases,
 			targetId: user.id,
 			targetTag: user.tag,
-			action: ACTIONS.BAN,
+			action: mode === 'BAN' ? ACTIONS.BAN : ACTIONS.KICK,
 		});
 	}
 }

--- a/src/bot/listeners/client/moderation/guildMemberAdd.ts
+++ b/src/bot/listeners/client/moderation/guildMemberAdd.ts
@@ -1,0 +1,54 @@
+import { Listener } from 'discord-akairo';
+import { GuildMember, TextChannel } from 'discord.js';
+import { SETTINGS, MESSAGES, COLORS, ACTIONS } from '../../../util/constants';
+import ms from '@naval-base/ms';
+
+export default class GuildMemberAddAntiraidListener extends Listener {
+	public constructor() {
+		super('guildMemberAddAntiraid', {
+			emitter: 'client',
+			event: 'guildMemberAdd',
+			category: 'client',
+		});
+	}
+
+	public async exec(member: GuildMember) {
+		const { guild, user } = member;
+		if (!this.client.settings.get(guild, SETTINGS.MODERATION)) return;
+
+		const mode = this.client.settings.get(guild, SETTINGS.ANTIRAID_MODE);
+		const age = this.client.settings.get(guild, SETTINGS.ANTIRAID_AGE);
+		if (!mode || !age) return;
+
+		if (Date.now() - user.createdTimestamp >= age) return;
+
+		if (this.client.caseHandler.cachedCases.delete(`${guild.id}:${user.id}:BAN`)) return;
+		const totalCases = this.client.settings.get(guild, SETTINGS.CASES, 0) + 1;
+		this.client.settings.set(guild, SETTINGS.CASES, totalCases);
+		const modLogChannel = this.client.settings.get(guild, SETTINGS.MOD_LOG);
+
+		let modMessage;
+		if (modLogChannel) {
+			const embed = (
+				await this.client.caseHandler.log({
+					member: member,
+					action: mode === 'BAN' ? 'Ban' : 'Kick',
+					caseNum: totalCases,
+					reason: MESSAGES.ANTIRAID.REASON(ms(age, true)),
+					message: { author: this.client.user!, guild: guild },
+					nsfw: true,
+				})
+			).setColor(COLORS.ANTIRAID);
+			modMessage = await (this.client.channels.cache.get(modLogChannel) as TextChannel).send(embed);
+		}
+
+		await this.client.caseHandler.create({
+			guild: guild.id,
+			message: modMessage?.id,
+			caseId: totalCases,
+			targetId: user.id,
+			targetTag: user.tag,
+			action: ACTIONS.BAN,
+		});
+	}
+}

--- a/src/bot/listeners/client/moderation/guildMemberAdd.ts
+++ b/src/bot/listeners/client/moderation/guildMemberAdd.ts
@@ -1,7 +1,6 @@
 import { Listener } from 'discord-akairo';
 import { GuildMember, TextChannel } from 'discord.js';
 import { SETTINGS, MESSAGES, COLORS, ACTIONS } from '../../../util/constants';
-import ms from '@naval-base/ms';
 
 export default class GuildMemberAddAntiraidListener extends Listener {
 	public constructor() {
@@ -34,7 +33,7 @@ export default class GuildMemberAddAntiraidListener extends Listener {
 					member: member,
 					action: mode === 'BAN' ? 'Ban' : 'Kick',
 					caseNum: totalCases,
-					reason: MESSAGES.ANTIRAID.REASON(ms(age, true)),
+					reason: MESSAGES.ANTIRAID.REASON,
 					message: { author: this.client.user!, guild: guild },
 					nsfw: true,
 				})

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -120,7 +120,7 @@ export const MESSAGES = {
 	},
 
 	ANTIRAID: {
-		REASON: (age: string) => `automated anti raid action (account age less than ${age})`,
+		REASON: `Automated anti raid action`,
 	},
 
 	COMMANDS: {

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -32,6 +32,7 @@ export enum COLORS {
 	TAG = 16776960,
 	WARN = 16776960,
 	ERROR = 15290191,
+	ANTIRAID = 4549089,
 
 	MEMBER_LEFT = 3092790,
 	MESSAGE_DELETE = 0x824aee,
@@ -54,6 +55,8 @@ export enum SETTINGS {
 	DEFAULT_DOCS = 'DEFAULT_DOCS',
 	BLACKLIST = 'BLACKLIST',
 	MEMBER_LOG = 'MEMBER_LOG',
+	ANTIRAID_MODE = 'ANTIRAID_MODE',
+	ANTIRAID_AGE = 'ANTIRAID_AGE',
 }
 
 export interface Settings {
@@ -79,6 +82,8 @@ export interface Settings {
 		ID: string;
 		MENTION: boolean;
 	};
+	ANTIRAID_MODE: string;
+	ANTIRAID_AGE: number;
 }
 
 export const MESSAGES = {
@@ -112,6 +117,10 @@ export const MESSAGES = {
 
 	LOCKDOWN_SCHEDULER: {
 		INIT: 'Lockdown scheduler initialized',
+	},
+
+	ANTIRAID: {
+		REASON: (age: string) => `automated anti raid action (account age less than ${age})`,
 	},
 
 	COMMANDS: {
@@ -550,6 +559,20 @@ export const MESSAGES = {
 
 				REMOVED: (channel: TextChannel) => `Successfully removed lockdown on ${channel}`,
 				REPLY: (channel: TextChannel) => `Successfully locked down ${channel}`,
+			},
+
+			ANTIRAID: {
+				DESCRIPTION: 'Configures the servers anti-raid mode using the provided parameters.',
+				PROMPT: {
+					START: (author: User | null) => `${author}, please pick one of \`ban|kick|disable\``,
+					RETRY: (author: User | null) => `${author}, please pick one of \`ban|kick|disable\``,
+				},
+
+				DISABLED: `Successfully disabled anti raid mode`,
+				NO_AGE: (author: User | null) =>
+					`${author}, you need to tell me the minimum age members can have without being actioned!`,
+				ENABLED: (action: string, age: string) =>
+					`Successfully enabled anti raid mode with action \`${action}\` for users with an account age under ${age}.`,
 			},
 
 			MUTE: {

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -120,7 +120,7 @@ export const MESSAGES = {
 	},
 
 	ANTIRAID: {
-		REASON: `Automated anti raid action`,
+		REASON: `Automated anti-raid action`,
 	},
 
 	COMMANDS: {
@@ -568,11 +568,11 @@ export const MESSAGES = {
 					RETRY: (author: User | null) => `${author}, please pick one of \`ban|kick|disable\``,
 				},
 
-				DISABLED: `Successfully disabled anti raid mode`,
+				DISABLED: `Successfully disabled anti-raid mode`,
 				NO_AGE: (author: User | null) =>
 					`${author}, you need to tell me the minimum age members can have without being actioned!`,
 				ENABLED: (action: string, age: string) =>
-					`Successfully enabled anti raid mode with action \`${action}\` for users with an account age under ${age}.`,
+					`Successfully enabled anti-raid mode with action \`${action}\` for users with an account age under ${age}.`,
 			},
 
 			MUTE: {


### PR DESCRIPTION
Add capability to lock down a guild based on provided action (kick/ban) and minimum account age.
1. command `?antiraid <kick|ban> <age> | <disable>`
1. guildMemberAdd listener to independently evaluate joins in the moderation category 
1. antiraid log color to easily discern cases regarding automod

PR is untested (as hasura hates me)