### PR TITLE
fix(antiraid): rework to execute actions

### DIFF
--- a/src/bot/listeners/client/moderation/guildMemberAdd.ts
+++ b/src/bot/listeners/client/moderation/guildMemberAdd.ts
@@ -1,6 +1,10 @@
 import { Listener } from 'discord-akairo';
-import { GuildMember, TextChannel } from 'discord.js';
-import { SETTINGS, MESSAGES, COLORS, ACTIONS } from '../../../util/constants';
+import { ACTIONS, PRODUCTION, SETTINGS, MESSAGES, COLORS, DATE_FORMAT_WITH_SECONDS } from '../../../util/constants';
+import { GuildMember, TextChannel, MessageEmbed } from 'discord.js';
+import { GRAPHQL, graphQLClient } from '../../../util/graphQL';
+import { Cases, CasesInsertInput } from '../../../util/graphQLTypes';
+import * as moment from 'moment';
+import { stripIndents } from 'common-tags';
 
 export default class GuildMemberAddAntiraidListener extends Listener {
 	public constructor() {
@@ -18,36 +22,93 @@ export default class GuildMemberAddAntiraidListener extends Listener {
 		const mode = this.client.settings.get(guild, SETTINGS.ANTIRAID_MODE);
 		const age = this.client.settings.get(guild, SETTINGS.ANTIRAID_AGE);
 		if (!mode || !age) return;
-
 		if (Date.now() - user.createdTimestamp >= age) return;
 
-		if (this.client.caseHandler.cachedCases.delete(`${guild.id}:${user.id}:BAN`)) return;
-		const totalCases = this.client.settings.get(guild, SETTINGS.CASES, 0) + 1;
-		this.client.settings.set(guild, SETTINGS.CASES, totalCases);
-		const modLogChannel = this.client.settings.get(guild, SETTINGS.MOD_LOG);
+		// Manually constructing the case due to restrictions in Action constructor
+		const key = `${guild.id}:${member.id}:${mode}`;
 
-		let modMessage;
-		if (modLogChannel) {
-			const embed = (
-				await this.client.caseHandler.log({
-					member: member,
-					action: mode === 'BAN' ? 'Ban' : 'Kick',
-					caseNum: totalCases,
-					reason: MESSAGES.ANTIRAID.REASON,
-					message: { author: this.client.user!, guild: guild },
-					nsfw: true,
-				})
-			).setColor(COLORS.ANTIRAID);
-			modMessage = await (this.client.channels.cache.get(modLogChannel) as TextChannel).send(embed);
+		// Action#before
+		this.client.caseHandler.cachedCases.add(key);
+
+		// Action#exec
+		const totalCases = this.client.settings.get(guild, SETTINGS.CASES, 0) + 1;
+
+		try {
+			await member.send(MESSAGES.ACTIONS.ANTIRAID.MESSAGE(guild.name, mode === 'BAN' ? 'banned' : 'kicked'));
+		} catch {}
+
+		const reason = MESSAGES.ACTIONS.ANTIRAID.AUDIT(mode.toLowerCase(), totalCases);
+		try {
+			if (mode === 'BAN') {
+				await guild.members.ban(member.id, { reason });
+			} else {
+				await member.kick(reason);
+			}
+		} catch (error) {
+			this.client.logger.error(error.message);
+			this.client.caseHandler.cachedCases.delete(key);
 		}
 
+		this.client.settings.set(guild, SETTINGS.CASES, totalCases);
+
+		// Action#after
 		await this.client.caseHandler.create({
 			guild: guild.id,
-			message: modMessage?.id,
 			caseId: totalCases,
-			targetId: user.id,
-			targetTag: user.tag,
+			targetId: member.id,
+			targetTag: member.user.tag,
+			modId: this.client.user?.id,
+			modTag: this.client.user?.id,
 			action: mode === 'BAN' ? ACTIONS.BAN : ACTIONS.KICK,
+			reason: MESSAGES.ANTIRAID.REASON,
 		});
+
+		const modLogChannel = this.client.settings.get(guild, SETTINGS.MOD_LOG);
+		if (modLogChannel) {
+			const sinceCreationFormatted = moment.utc(member.user.createdAt ?? 0).fromNow();
+			const creationFormatted = moment.utc(member.user.createdAt ?? 0).format(DATE_FORMAT_WITH_SECONDS);
+			const sinceJoinFormatted = moment.utc(member.joinedAt ?? 0).fromNow();
+			const joinFormatted = moment.utc().format(DATE_FORMAT_WITH_SECONDS);
+
+			const { data } = await graphQLClient.query<any, CasesInsertInput>({
+				query: GRAPHQL.QUERY.LOG_CASE,
+				variables: {
+					guild: guild.id,
+					caseId: totalCases,
+				},
+			});
+
+			let dbCase: Pick<Cases, 'id' | 'message'>;
+			if (PRODUCTION) dbCase = data.cases[0];
+			else dbCase = data.casesStaging[0];
+			if (dbCase) {
+				const embed = new MessageEmbed()
+					.setColor(COLORS.ANTIRAID)
+					.setAuthor(MESSAGES.ANTIRAID.REASON)
+					.setDescription(
+						stripIndents`
+							**Member:** ${member.user.tag} (${member.user.id})
+							**Action:** ${mode.toLowerCase().replace(/(^|\s)\S/g, (t) => t.toUpperCase())}
+							**Created:** ${sinceCreationFormatted} (${creationFormatted})
+							**Joined:** ${sinceJoinFormatted} (${joinFormatted})
+						`,
+					)
+					.setFooter(`Case ${totalCases}`)
+					.setTimestamp(new Date());
+
+				try {
+					const modMessage = await (this.client.channels.cache.get(modLogChannel) as TextChannel).send(embed);
+					await graphQLClient.mutate<any, CasesInsertInput>({
+						mutation: GRAPHQL.MUTATION.LOG_CASE,
+						variables: {
+							id: dbCase.id,
+							message: modMessage.id,
+						},
+					});
+				} catch (error) {
+					this.client.logger.error(error.message);
+				}
+			}
+		}
 	}
 }

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -874,7 +874,7 @@ export const MESSAGES = {
 				**Reason:** Automated anti-raid measure
 				${action === 'banned' ? 'You can appeal by DMing `Crawl#0002` with a message explaining the situation.' : ''}
 			`,
-			AUDIT: (action: string, cases: number) => `Automated ${action}| Case #${cases}`,
+			AUDIT: (action: string, cases: number) => `Automated ${action} | Case #${cases}`,
 		},
 
 		BAN: {

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -868,6 +868,15 @@ export const MESSAGES = {
 		NO_RESTRICT: 'there are no restricted roles configured on this server.',
 		NO_MUTE: 'there is no mute role configured on this server.',
 
+		ANTIRAID: {
+			MESSAGE: (guild: string, action: string) => stripIndents`
+				**You have been ${action} from ${guild}**
+				**Reason:** Automated anti-raid measure
+				${action === 'banned' ? 'You can appeal by DMing `Crawl#0002` with a message explaining the situation.' : ''}
+			`,
+			AUDIT: (action: string, cases: number) => `Automated ${action}| Case #${cases}`,
+		},
+
 		BAN: {
 			AWAIT_MESSAGE: 'You sure you want me to ban this [no gender specified]?',
 			TIMEOUT: 'timed out. Cancelled ban.',


### PR DESCRIPTION
Rework antiraid, this time it hopefully actually does things instead of just logging them. The Action utility can't be used due to its dependence on a message, which is not available for automated on-join bans. PR is untested