### PR TITLE
feat: multi ban command

### DIFF
--- a/src/bot/commands/mod/multiban.ts
+++ b/src/bot/commands/mod/multiban.ts
@@ -117,6 +117,7 @@ export default class MultiBanCommand extends Command {
 			`${MESSAGES.COMMANDS.MOD.MULTIBAN.PROMPT.CONFIRMATION(message.author, validTargetString)} (y/n)${
 				parts.length ? `\n${parts.join('\n')}` : ''
 			}`,
+			{ split: true },
 		);
 
 		const filter = (m: Message) =>

--- a/src/bot/commands/mod/multiban.ts
+++ b/src/bot/commands/mod/multiban.ts
@@ -10,7 +10,7 @@ export default class MultiBanCommand extends Command {
 			aliases: ['multiban', 'massban', 'nuke'],
 			description: {
 				content: MESSAGES.COMMANDS.MOD.MULTIBAN.DESCRIPTION,
-				usage: '<...members>',
+				usage: '<...user>',
 				examples: ['81440962496172032 83886770768314368'],
 			},
 			category: 'mod',

--- a/src/bot/commands/mod/multiban.ts
+++ b/src/bot/commands/mod/multiban.ts
@@ -15,7 +15,11 @@ export default class MultiBanCommand extends Command {
 			},
 			category: 'mod',
 			userPermissions: [Permissions.FLAGS.MANAGE_GUILD],
-			clientPermissions: [Permissions.FLAGS.BAN_MEMBERS, Permissions.FLAGS.MANAGE_GUILD],
+			clientPermissions: [
+				Permissions.FLAGS.BAN_MEMBERS,
+				Permissions.FLAGS.MANAGE_GUILD,
+				Permissions.FLAGS.ATTACH_FILES,
+			],
 			ratelimit: 2,
 			flags: ['--report', '-r'],
 			channel: 'guild',
@@ -33,11 +37,22 @@ export default class MultiBanCommand extends Command {
 					match: 'flag',
 					flag: ['--report', '-r'],
 				},
+				{
+					id: 'days',
+					type: 'integer',
+					match: 'option',
+					flag: ['--days=', '-d='],
+					default: 1,
+				},
 			],
 		});
 	}
 
-	public async exec(message: Message, { targets, report }: { targets: Array<GuildMember | string>; report: boolean }) {
+	public async exec(
+		message: Message,
+		{ targets, report, days }: { targets: Array<GuildMember | string>; report: boolean; days: number },
+	) {
+		days = Math.min(Math.max(days, 0), 7);
 		const guild = message.guild!;
 
 		await message.util?.send('Making preparations...');
@@ -133,6 +148,7 @@ export default class MultiBanCommand extends Command {
 				for (const user of validTargets.values()) {
 					try {
 						await guild.members.ban(user, {
+							days,
 							reason: `Multi ban by ${message.author.tag} (${++i}/${validTargets.size})`,
 						});
 						confirmed.set(user.id, user);

--- a/src/bot/commands/mod/multiban.ts
+++ b/src/bot/commands/mod/multiban.ts
@@ -1,0 +1,166 @@
+import { Argument, Command } from 'discord-akairo';
+import { GuildMember, Message, Permissions, Collection, MessageAttachment, User } from 'discord.js';
+import { DATE_FORMAT_LOGFILE, MESSAGES } from '../../util/constants';
+import { EVENTS, TOPICS } from '../../util/logger';
+import * as moment from 'moment';
+
+export default class MultiBanCommand extends Command {
+	public constructor() {
+		super('multiban', {
+			aliases: ['multiban', 'massban', 'nuke'],
+			description: {
+				content: MESSAGES.COMMANDS.MOD.MULTIBAN.DESCRIPTION,
+				usage: '<...members>',
+				examples: ['81440962496172032 83886770768314368'],
+			},
+			category: 'mod',
+			userPermissions: [Permissions.FLAGS.MANAGE_GUILD],
+			clientPermissions: [Permissions.FLAGS.BAN_MEMBERS, Permissions.FLAGS.MANAGE_GUILD],
+			ratelimit: 2,
+			flags: ['--report', '-r'],
+			channel: 'guild',
+			args: [
+				{
+					id: 'targets',
+					type: Argument.union('member', 'string'),
+					match: 'separate',
+					prompt: {
+						start: (message: Message) => MESSAGES.COMMANDS.MOD.MULTIBAN.PROMPT.START(message.author),
+					},
+				},
+				{
+					id: 'report',
+					match: 'flag',
+					flag: ['--report', '-r'],
+				},
+			],
+		});
+	}
+
+	public async exec(message: Message, { targets, report }: { targets: Array<GuildMember | string>; report: boolean }) {
+		const guild = message.guild!;
+
+		await message.util?.send('Making preparations...');
+		await guild.members.fetch();
+
+		let invalidInput = 0;
+		let currentlyManaged = 0;
+		let notManageable = 0;
+		let alreadyBanned = 0;
+
+		const validTargets: Collection<string, User> = new Collection();
+
+		const bans = await guild.fetchBans();
+		for (const value of targets) {
+			const member = value instanceof GuildMember ? value : guild.member(value);
+			if (member) {
+				if (!member.bannable || member.roles.highest.position >= message.member!.roles.highest.position) {
+					notManageable++;
+					continue;
+				}
+
+				const key = `${guild.id}:${member.id}:BAN`;
+				if (this.client.caseHandler.cachedCases.has(key)) {
+					currentlyManaged++;
+					continue;
+				}
+
+				validTargets.set(member.id, member.user);
+				continue;
+			}
+
+			try {
+				const user = await this.client.users.fetch(value as string);
+				if (bans.has(user.id)) {
+					alreadyBanned++;
+					continue;
+				}
+				validTargets.set(user.id, user);
+			} catch {
+				invalidInput++;
+			}
+		}
+
+		const parts: string[] = [];
+
+		if (!validTargets.size) {
+			parts.push(MESSAGES.COMMANDS.MOD.MULTIBAN.FAIL.VALID_USER);
+		}
+
+		const filteredSum = invalidInput + currentlyManaged + notManageable + alreadyBanned;
+		if (filteredSum) {
+			parts.push(MESSAGES.COMMANDS.MOD.MULTIBAN.INVALID.FILTERED);
+		}
+
+		if (invalidInput) {
+			parts.push(MESSAGES.COMMANDS.MOD.MULTIBAN.INVALID.INPUT(invalidInput));
+		}
+
+		if (currentlyManaged) {
+			parts.push(MESSAGES.COMMANDS.MOD.MULTIBAN.INVALID.MANAGED(currentlyManaged));
+		}
+
+		if (notManageable) {
+			parts.push(MESSAGES.COMMANDS.MOD.MULTIBAN.INVALID.MANAGEABLE(notManageable));
+		}
+
+		if (alreadyBanned) {
+			parts.push(MESSAGES.COMMANDS.MOD.MULTIBAN.INVALID.BANNED(alreadyBanned));
+		}
+
+		if (!validTargets.size) {
+			return message.util?.send(parts.join('\n'));
+		}
+
+		const validTargetString = validTargets.map((u) => `\`${u.tag}\``).join(', ');
+		message.util?.send(
+			`${MESSAGES.COMMANDS.MOD.MULTIBAN.PROMPT.CONFIRMATION(message.author, validTargetString)} (y/n)${
+				parts.length ? `\n${parts.join('\n')}` : ''
+			}`,
+		);
+
+		const filter = (m: Message) =>
+			m.author.id === message.author.id && ['y', 'yes', 'n', 'no'].includes(m.content.toLowerCase());
+
+		try {
+			const collected = await message.channel.awaitMessages(filter, { max: 1, time: 20000, errors: ['time'] });
+			if (['yes', 'y'].includes(collected.first()!.content)) {
+				const survivors: Collection<string, User> = new Collection();
+				const confirmed: Collection<string, User> = new Collection();
+
+				let i = 0;
+				for (const user of validTargets.values()) {
+					try {
+						await guild.members.ban(user, {
+							reason: `Multi ban by ${message.author.tag} (${++i}/${validTargets.size})`,
+						});
+						confirmed.set(user.id, user);
+					} catch (err) {
+						this.client.logger.error(err, { topic: TOPICS.DISCORD, event: EVENTS.COMMAND_ERROR });
+						survivors.set(user.id, user);
+					}
+				}
+
+				const confirmedString = confirmed.map((u: User) => `\`${u.tag}\``).join(', ');
+				const survivorString = survivors.map((u: User) => `\`${u.tag}\``).join(', ');
+
+				await message.channel.send(
+					MESSAGES.COMMANDS.MOD.MULTIBAN.SUCCESS(confirmedString || 'none', survivorString || 'none'),
+					{ split: true },
+				);
+
+				if (report) {
+					const buffer = Buffer.from(confirmed.map((u) => u.id).join('\r\n'));
+					const d = moment.utc().format(DATE_FORMAT_LOGFILE);
+					const attachment = new MessageAttachment(buffer, `${d} multiban-report.txt`);
+
+					return message.channel.send(MESSAGES.COMMANDS.MOD.MULTIBAN.REPORT, [attachment]);
+				}
+				return null;
+			}
+			return message.util?.send(MESSAGES.COMMANDS.MOD.MULTIBAN.FAIL.CONFIRMATION);
+		} catch {
+			message.util?.send(MESSAGES.COMMANDS.MOD.MULTIBAN.FAIL.TIMEOUT);
+		}
+	}
+}

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -20,6 +20,8 @@ export const MAX_TRUST_ACCOUNT_AGE = 1000 * 60 * 60 * 24 * 7 * 4;
 
 export const DATE_FORMAT_WITH_SECONDS = 'YYYY/MM/DD hh:mm:ss';
 
+export const DATE_FORMAT_LOGFILE = 'YYYY-MM-DD hh-mm-ss';
+
 export enum COLORS {
 	BAN = 16718080,
 	UNBAN = 8450847,
@@ -517,6 +519,29 @@ export const MESSAGES = {
 					START: (author: User | null) => `${author}, what member do you want to ban?`,
 					RETRY: (author: User | null) => `${author}, please mention a member.`,
 				},
+			},
+
+			MULTIBAN: {
+				DESCRIPTION: 'Bans provided members',
+				PROMPT: {
+					START: (author: User | null) => `${author}, which members do you want me to ban?`,
+					RETRY: (author: User | null) => `${author}, you have to provide members to ban!`,
+					CONFIRMATION: (author: User | null, members: string) => `${author}, awaiting confirmation to ban ${members}`,
+				},
+				INVALID: {
+					FILTERED: `Invalid users filtered:`,
+					INPUT: (amount: number) => `• Invalid input: ${amount}`,
+					MANAGED: (amount: number) => `• Currently being managed: ${amount}`,
+					MANAGEABLE: (amount: number) => `• Users not manageable by the client or yourself: ${amount}`,
+					BANNED: (amount: number) => `• Already banned: ${amount}`,
+				},
+				FAIL: {
+					VALID_USER: `Command execution failed. Provide at least one valid user to ban.`,
+					TIMEOUT: `Action timed out.`,
+					CONFIRMATION: `Action cancelled.`,
+				},
+				SUCCESS: (confirmed: string, survivors: string) => `• Banned: ${confirmed}\n• Survivors: ${survivors}`,
+				REPORT: 'The requested report is ready!',
 			},
 
 			DURATION: {


### PR DESCRIPTION
Adds a feature to ban multiple members in one go.

- checks current bans, hierarchy, currently managed users and validates global user ids
- filters and still allows a ban as long as a single valid user was provided
- asks for confirmation and provides insight on how many were filtered for what reason
- bans the valid members.
- `-r`, `--report` flag to return a .txt file with all successfully banned user IDs separated by newline, for easier T&S reporting