### PR TITLE
feat(cybernuke): improve verbosity and ux

### DIFF
--- a/src/bot/commands/util/cybernuke.ts
+++ b/src/bot/commands/util/cybernuke.ts
@@ -59,7 +59,7 @@ export default class LaunchCybernukeCommand extends Command {
 					type: 'integer',
 					match: 'option',
 					flag: ['--days=', '-d='],
-					default: 7,
+					default: 1,
 				},
 			],
 		});

--- a/src/bot/commands/util/cybernuke.ts
+++ b/src/bot/commands/util/cybernuke.ts
@@ -54,11 +54,23 @@ export default class LaunchCybernukeCommand extends Command {
 					match: 'flag',
 					flag: ['--report', '-r'],
 				},
+				{
+					id: 'days',
+					type: 'integer',
+					match: 'option',
+					flag: ['--days=', '-d='],
+					default: 7,
+				},
 			],
 		});
 	}
 
-	public async exec(message: Message, { join, age, report }: { join: number; age: number; report: boolean }) {
+	public async exec(
+		message: Message,
+		{ join, age, report, days }: { join: number; age: number; report: boolean; days: number },
+	) {
+		days = Math.min(Math.max(days, 0), 7);
+
 		const guild = message.guild!;
 		await message.util?.send('Calculating targeting parameters for cybernuke...');
 		const fetchedMembers = await guild.members.fetch();
@@ -114,7 +126,7 @@ export default class LaunchCybernukeCommand extends Command {
 								this.client.logger.error(error, { topic: TOPICS.DISCORD, event: EVENTS.COMMAND_ERROR });
 							})
 							.then(async () =>
-								member.ban({ days: 7, reason: `Cybernuke by ${message.author.tag} (${++i}/${members.size})` }),
+								member.ban({ days, reason: `Cybernuke by ${message.author.tag} (${++i}/${members.size})` }),
 							)
 							.then(() => {
 								fatalities.push(member);

--- a/src/bot/commands/util/cybernuke.ts
+++ b/src/bot/commands/util/cybernuke.ts
@@ -1,9 +1,10 @@
 import { stripIndents } from 'common-tags';
-import { Argument, Command } from 'discord-akairo';
+import { Command } from 'discord-akairo';
 import { GuildMember, Message, Permissions, MessageAttachment } from 'discord.js';
 import { MESSAGES, DATE_FORMAT_LOGFILE } from '../../util/constants';
-import { EVENTS, TOPICS } from '../../util/logger';
 import * as moment from 'moment';
+import { ms } from '@naval-base/ms';
+import { EVENTS, TOPICS } from '../../util/logger';
 
 export default class LaunchCybernukeCommand extends Command {
 	public constructor() {
@@ -21,18 +22,31 @@ export default class LaunchCybernukeCommand extends Command {
 			args: [
 				{
 					id: 'join',
-					type: Argument.range('number', 0.1, 120, true),
+					type: (_, str): number | null => {
+						if (!str) return null;
+						const duration = ms(str);
+						if (isNaN(duration)) return null;
+						if (duration < 6000) return null;
+						if (duration > 120 * 60 * 1000) return null;
+						return duration;
+					},
 					prompt: {
-						start: (message: Message) => MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.START(message.author),
-						retry: (message: Message) => MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.RETRY(message.author),
+						start: (message: Message) => MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.JOIN.START(message.author),
+						retry: (message: Message) => MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.JOIN.RETRY(message.author),
 					},
 				},
 				{
 					id: 'age',
-					type: Argument.range('number', 0.1, Infinity, true),
+					type: (_, str): number | null => {
+						if (!str) return null;
+						const duration = ms(str);
+						if (isNaN(duration)) return null;
+						if (duration < 6000) return null;
+						return duration;
+					},
 					prompt: {
-						start: (message: Message) => MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT_2.START(message.author),
-						retry: (message: Message) => MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT_2.RETRY(message.author),
+						start: (message: Message) => MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.AGE.START(message.author),
+						retry: (message: Message) => MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.AGE.RETRY(message.author),
 					},
 				},
 				{
@@ -47,107 +61,113 @@ export default class LaunchCybernukeCommand extends Command {
 	public async exec(message: Message, { join, age, report }: { join: number; age: number; report: boolean }) {
 		const guild = message.guild!;
 		await message.util?.send('Calculating targeting parameters for cybernuke...');
-		await guild.members.fetch();
+		const fetchedMembers = await guild.members.fetch();
 
-		const memberCutoff = Date.now() - join * 60000;
-		const ageCutoff = Date.now() - age * 60000;
-		const members = guild.members.cache.filter(
-			(member) => (member.joinedTimestamp ?? 0) > memberCutoff && member.user.createdTimestamp > ageCutoff,
+		const joinCutoff = Date.now() - join;
+		const ageCutoff = Date.now() - age;
+
+		const joinCutoffFormatted = moment.utc(joinCutoff).format('YYYY/MM/DD hh:mm:ss');
+		const ageCutoffFormatted = moment.utc(ageCutoff).format('YYYY/MM/DD hh:mm:ss');
+
+		const members = fetchedMembers.filter(
+			(member) => (member.joinedTimestamp ?? 0) > joinCutoff && member.user.createdTimestamp > ageCutoff,
 		);
 
-		await message.util?.send(`Cybernuke will strike ${members.size} members; proceed?`);
-		let statusMessage: Message | undefined;
-
-		const responses = await message.channel.awaitMessages((msg: Message) => msg.author.id === message.author.id, {
-			max: 1,
-			time: 10000,
-		});
-
-		if (responses?.size !== 1) {
-			await message.reply('Cybernuke cancelled.');
-			return null;
-		}
-		const response = responses.first();
-
-		if (/^y(?:e(?:a|s)?)?$/i.test(response?.content ?? '')) {
-			statusMessage = await response?.reply('Launching cybernuke...');
-		} else {
-			await response?.reply('Cybernuke cancelled.');
-			return null;
-		}
-
-		const fatalities: GuildMember[] = [];
-		const survivors: { member: GuildMember; error: Error }[] = [];
-		const promises: Promise<Message | void>[] = [];
-
-		for (const member of members.values()) {
-			promises.push(
-				member
-					.send(
-						stripIndents`
-					Sorry, but you've been automatically targeted by the cybernuke in the "${guild.name}" server.
-					This means that you have been banned, likely in the case of a server raid.
-					Please contact them if you believe this ban to be in error.
-				`,
-					)
-					.catch((error: any) =>
-						this.client.logger.error(error, { topic: TOPICS.DISCORD, event: EVENTS.COMMAND_ERROR }),
-					)
-					.then(async () => member.ban({ days: 7, reason: 'Cybernuke!' }))
-					.then(() => {
-						fatalities.push(member);
-					})
-					.catch((err: any) => {
-						this.client.logger.error(err, { topic: TOPICS.DISCORD, event: EVENTS.COMMAND_ERROR });
-						survivors.push({
-							member,
-							error: err,
-						});
-					})
-					.then(async () => {
-						if (members.size <= 5) return;
-						if (promises.length % 5 === 0) {
-							await statusMessage?.edit(
-								`Launching cyber nuke (${Math.round((promises.length / members.size) * 100)}%)...`,
-							);
-						}
-					}),
+		if (!members.size) {
+			return message.util?.send(
+				MESSAGES.COMMANDS.UTIL.CYBERNUKE.FAIL.NO_MEMBERS(`${joinCutoffFormatted} (UTC)`, `${ageCutoffFormatted} (UTC)`),
 			);
 		}
 
-		await Promise.all(promises);
-		await statusMessage?.edit('Cybernuke impact confirmed. Casualty report incoming...');
-		await response?.reply(
-			stripIndents`
-			__**Fatalities:**__
-
-			${
-				fatalities.length > 0
-					? stripIndents`
-					${fatalities.length} confirmed KIA.
-					${fatalities.map((fat) => `**-** ${fat.displayName} (${fat.id})`).join('\n')}
-				`
-					: 'None'
-			}
-			${
-				survivors.length > 0
-					? stripIndents`
-					__**Survivors**__
-					${survivors.length} left standing.
-					${survivors.map((srv) => `**-** ${srv.member.displayName} (${srv.member.id}): \`${srv.error}\``).join('\n')}
-				`
-					: ''
-			}
-		`,
-			{ split: true },
+		await message.util?.send(
+			MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.CONFIRMATION(
+				message.author,
+				members.size,
+				`${joinCutoffFormatted} (UTC)`,
+				`${ageCutoffFormatted} (UTC)`,
+			),
 		);
 
-		if (report) {
-			const buffer = Buffer.from(fatalities.map((u) => u.id).join('\r\n'));
-			const d = moment.utc().format(DATE_FORMAT_LOGFILE);
-			const attachment = new MessageAttachment(buffer, `${d} cybernuke-report.txt`);
+		const filter = (m: Message) =>
+			m.author.id === message.author.id && ['y', 'yes', 'n', 'no'].includes(m.content.toLowerCase());
 
-			await message.channel.send(MESSAGES.COMMANDS.UTIL.CYBERNUKE.REPORT, [attachment]);
+		try {
+			const collected = await message.channel.awaitMessages(filter, { max: 1, time: 20000, errors: ['time'] });
+			if (['yes', 'y'].includes(collected.first()!.content)) {
+				const statusMessage = await message?.channel.send('Launching cybernuke...');
+
+				const fatalities: GuildMember[] = [];
+				const survivors: { member: GuildMember; error: Error }[] = [];
+				const promises: Promise<Message | void>[] = [];
+
+				let i = 0;
+				for (const member of members.values()) {
+					promises.push(
+						member
+							.send(
+								stripIndents`
+									You have been banned from \`${guild.name}\` as part of anti raid measures.
+									Please contact \`Crawl#0002\`, explaining the situation if you believe this to be an error.
+								`,
+							)
+							.catch((error: any) => {
+								this.client.logger.error(error, { topic: TOPICS.DISCORD, event: EVENTS.COMMAND_ERROR });
+							})
+							.then(async () =>
+								member.ban({ days: 7, reason: `Cybernuke by ${message.author.tag} (${++i}/${members.size})` }),
+							)
+							.then(() => {
+								fatalities.push(member);
+							})
+							.catch((err: any) => {
+								this.client.logger.error(err, { topic: TOPICS.DISCORD, event: EVENTS.COMMAND_ERROR });
+								survivors.push({
+									member,
+									error: err,
+								});
+							})
+							.then(async () => {
+								if (members.size <= 5) return;
+								if (promises.length % 5 === 0) {
+									await statusMessage?.edit(
+										`Launching cyber nuke (${Math.round((promises.length / members.size) * 100)}%)...`,
+									);
+								}
+							}),
+					);
+				}
+
+				await Promise.all(promises);
+				await statusMessage?.edit('Cybernuke impact confirmed. Casualty report incoming...');
+				const parts: string[] = [];
+
+				if (fatalities.length) {
+					parts.push(`__Fatalities (${fatalities.length})__`);
+					parts.push(fatalities.map((fat) => `• \`${fat.user.tag}\` (${fat.id})`).join('\n'));
+				}
+
+				if (survivors.length) {
+					parts.push(`__Survivors (${survivors.length})__`);
+					parts.push(
+						survivors.map((srv) => `•  \`${srv.member.user.tag}\` (${srv.member.id}) \`${srv.error}\``).join('\n'),
+					);
+				}
+				await message.channel.send(parts.join('\n'), { split: true });
+
+				if (report) {
+					const buffer = Buffer.from(fatalities.map((u) => u.id).join('\r\n'));
+					const d = moment.utc().format(DATE_FORMAT_LOGFILE);
+					const attachment = new MessageAttachment(buffer, `${d} cybernuke-report.txt`);
+
+					await message.channel.send(MESSAGES.COMMANDS.UTIL.CYBERNUKE.REPORT, [attachment]);
+				}
+
+				return null;
+			}
+
+			return message.util?.send(MESSAGES.COMMANDS.UTIL.CYBERNUKE.FAIL.CONFIRMATION);
+		} catch {
+			message.util?.send(MESSAGES.COMMANDS.UTIL.CYBERNUKE.FAIL.TIMEOUT);
 		}
 
 		return null;

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -20,6 +20,8 @@ export const MAX_TRUST_ACCOUNT_AGE = 1000 * 60 * 60 * 24 * 7 * 4;
 
 export const DATE_FORMAT_WITH_SECONDS = 'YYYY/MM/DD hh:mm:ss';
 
+export const DATE_FORMAT_LOGFILE = 'YYYY-MM-DD hh-mm-ss';
+
 export enum COLORS {
 	BAN = 16718080,
 	UNBAN = 8450847,
@@ -790,6 +792,7 @@ export const MESSAGES = {
 						`${author}, how old (in minutes) should a member's account be for the cybernuke to ignore them (account age)?`,
 					RETRY: (author: User | null) => `${author}, the minimum is \`0.1\` minutes.`,
 				},
+				REPORT: 'The requested report is ready!',
 			},
 
 			EVAL: {

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -783,16 +783,26 @@ export const MESSAGES = {
 			CYBERNUKE: {
 				DESCRIPTION: 'Bans all members that have joined recently, with new accounts.',
 				PROMPT: {
-					START: (author: User | null) =>
-						`${author}, how old (in minutes) should a member be for the cybernuke to ignore them (server join date)?`,
-					RETRY: (author: User | null) => `${author}, the minimum is \`0.1\` and the maximum \`120\` minutes.`,
-				},
-				PROMPT_2: {
-					START: (author: User | null) =>
-						`${author}, how old (in minutes) should a member's account be for the cybernuke to ignore them (account age)?`,
-					RETRY: (author: User | null) => `${author}, the minimum is \`0.1\` minutes.`,
+					JOIN: {
+						START: (author: User | null) =>
+							`${author}, how old (in minutes) should a member be for the cybernuke to ignore them (server join date)?`,
+						RETRY: (author: User | null) => `${author}, the minimum is \`6 seconds\` and the maximum \`2 hours\`.`,
+					},
+					AGE: {
+						START: (author: User | null) =>
+							`${author}, how old (in minutes) should a member's account be for the cybernuke to ignore them (account age)?`,
+						RETRY: (author: User | null) => `${author}, the minimum is \`6 seconds\`.`,
+					},
+					CONFIRMATION: (author: User | null, members: number, join: string, age: string) =>
+						`${author}, cybernuke is projected to hit \`${members}\` guild members. Proceed? (y/n)\nParameters:\n• Join Date after: ${join}\n• Account Creation after: ${age}`,
 				},
 				REPORT: 'The requested report is ready!',
+				FAIL: {
+					NO_MEMBERS: (join: string, age: string) =>
+						`Command execution failed. This cybernuke will not hit anyone, you might want to re-adjust the parameters and try again!\nParameters:\n• Join Date after: ${join}\n• Account Creation after: ${age}`,
+					CONFIRMATION: 'Action cancelled.',
+					TIMEOUT: 'Action timed out.',
+				},
 			},
 
 			EVAL: {


### PR DESCRIPTION
- take input in ms format `1d`, `1h`, `2m`, `20s` etc. rather than raw milliseconds
- provide feedback to the user what the chosen cutoff dates are so they can adjust the parameters in the next attempt
- add `-r`, `--report` flag to return a .txt file with all successfully banned user IDs separated by newline, for easier T&S reporting
- ignore answers that are not y,yes,n,no
- streamline response with new multiban command
- add appeal address to cybernuke target notification
- add executor and counter to reason