### PR TITLE
chore: consistent day defaulting and bounds

### DIFF
--- a/src/bot/commands/mod/ban.ts
+++ b/src/bot/commands/mod/ban.ts
@@ -33,7 +33,7 @@ export default class BanCommand extends Command {
 					type: 'integer',
 					match: 'option',
 					flag: ['--days=', '-d='],
-					default: 7,
+					default: 1,
 				},
 				{
 					id: 'ref',
@@ -66,6 +66,7 @@ export default class BanCommand extends Command {
 			reason,
 		}: { member: GuildMember | User; days: number; ref: number; nsfw: boolean; reason: string },
 	) {
+		days = Math.min(Math.max(days, 0), 7);
 		const guild = message.guild!;
 		const key = `${guild.id}:${member.id}:BAN`;
 		guild.caseQueue.add(async () =>

--- a/src/bot/commands/mod/softban.ts
+++ b/src/bot/commands/mod/softban.ts
@@ -63,6 +63,7 @@ export default class SoftbanCommand extends Command {
 			reason,
 		}: { member: GuildMember; days: number; ref: number; nsfw: boolean; reason: string },
 	) {
+		days = Math.min(Math.max(days, 0), 7);
 		const guild = message.guild!;
 		const keys = [`${guild.id}:${member.id}:BAN`, `${guild.id}:${member.id}:UNBAN`];
 		guild.caseQueue.add(async () =>


### PR DESCRIPTION
- Softban, ban, cybernuke and about to be added multiban should not differ in default usage
- 1 day is feasible, the chances that people hit by destructive actions go more than one day undetected is very low (for these cases the flag can still be specified).
- bounds handling: min days is 0 (no messages deleted) max days is 7