### PR TITLE
feat(*): various qol features

### DIFF
--- a/src/bot/commands/mod/antiraid.ts
+++ b/src/bot/commands/mod/antiraid.ts
@@ -10,7 +10,7 @@ export default class AntiraidCommand extends Command {
 			category: 'mod',
 			description: {
 				content: MESSAGES.COMMANDS.MOD.ANTIRAID.DESCRIPTION,
-				usage: '<kick|ban> <age> | <disable>',
+				usage: '<kick|ban> <<age>|disable>',
 				examples: ['kick 10h', 'ban 1w', 'disable'],
 			},
 			channel: 'guild',

--- a/src/bot/commands/mod/cases/show.ts
+++ b/src/bot/commands/mod/cases/show.ts
@@ -79,7 +79,7 @@ export default class CaseCommand extends Command {
 			.setColor(COLORS[color])
 			.setDescription(
 				stripIndents`
-				**Member:** ${dbCase.targetTag} (${dbCase.targetId})
+				**Member:** \`${dbCase.targetTag}\` (${dbCase.targetId})
 				**Action:** ${ACTION_KEYS[dbCase.action]}${
 					dbCase.action === 5
 						? `\n**Length:** ${ms(

--- a/src/bot/commands/mod/history.ts
+++ b/src/bot/commands/mod/history.ts
@@ -34,7 +34,6 @@ export default class HistoryCommand extends Command {
 					flag: ['--cases', '-c'],
 				},
 			],
-			flags: ['--profile', '-p'],
 			before: (message) => message.guild?.members.fetch(),
 		});
 	}

--- a/src/bot/commands/mod/history.ts
+++ b/src/bot/commands/mod/history.ts
@@ -10,8 +10,8 @@ export default class HistoryCommand extends Command {
 			category: 'mod',
 			description: {
 				content: MESSAGES.COMMANDS.MOD.HISTORY.DESCRIPTION,
-				usage: '<member>',
-				examples: ['@Crawl'],
+				usage: '<member> [--profile] [--cases]',
+				examples: ['@Crawl', '@Crawl --profile', '81440962496172032 --cases'],
 			},
 			channel: 'guild',
 			clientPermissions: [Permissions.FLAGS.MANAGE_ROLES, Permissions.FLAGS.EMBED_LINKS],

--- a/src/bot/commands/mod/history.ts
+++ b/src/bot/commands/mod/history.ts
@@ -28,32 +28,42 @@ export default class HistoryCommand extends Command {
 					match: 'flag',
 					flag: ['--profile', '-p'],
 				},
+				{
+					id: 'showCases',
+					match: 'flag',
+					flag: ['--cases', '-c'],
+				},
 			],
 			flags: ['--profile', '-p'],
 			before: (message) => message.guild?.members.fetch(),
 		});
 	}
 
-	public async exec(message: Message, { member, showProfile }: { member: GuildMember | string; showProfile: boolean }) {
+	public async exec(
+		message: Message,
+		{ member, showProfile, showCases }: { member: GuildMember | string; showProfile: boolean; showCases: boolean },
+	) {
 		const staffRole = message.member?.roles.cache.has(this.client.settings.get(message.guild!, SETTINGS.MOD_ROLE));
 		if (!staffRole) return;
 
 		const userInfoCmd = this.handler.findCommand('user') as UserInfoCommand;
 
 		if (member instanceof GuildMember) {
-			const embed = await this.client.caseHandler.history(member);
+			const embed = await this.client.caseHandler.history(member, showCases);
 			if (showProfile) {
 				userInfoCmd.addMemberDetails(embed, member);
 				userInfoCmd.addUserDetails(embed, member.user);
+				embed.thumbnail = null;
 			}
 			return message.util?.send(embed);
 		}
 
 		try {
 			const user = await this.client.users.fetch(member);
-			const embed = await this.client.caseHandler.history(user);
+			const embed = await this.client.caseHandler.history(user, showCases);
 			if (showProfile) {
 				userInfoCmd.addUserDetails(embed, user);
+				embed.thumbnail = null;
 			}
 			return message.util?.send(embed);
 		} catch {}

--- a/src/bot/commands/mod/history.ts
+++ b/src/bot/commands/mod/history.ts
@@ -1,6 +1,6 @@
 import { Argument, Command } from 'discord-akairo';
 import { GuildMember, Message, Permissions } from 'discord.js';
-import { MESSAGES, SETTINGS } from '../../util/constants';
+import { MESSAGES } from '../../util/constants';
 import UserInfoCommand from '../info/user';
 
 export default class HistoryCommand extends Command {
@@ -43,9 +43,6 @@ export default class HistoryCommand extends Command {
 		message: Message,
 		{ member, showProfile, showCases }: { member: GuildMember | string; showProfile: boolean; showCases: boolean },
 	) {
-		const staffRole = message.member?.roles.cache.has(this.client.settings.get(message.guild!, SETTINGS.MOD_ROLE));
-		if (!staffRole) return;
-
 		const userInfoCmd = this.handler.findCommand('user') as UserInfoCommand;
 
 		if (member instanceof GuildMember) {

--- a/src/bot/commands/mod/history.ts
+++ b/src/bot/commands/mod/history.ts
@@ -66,6 +66,8 @@ export default class HistoryCommand extends Command {
 				embed.thumbnail = null;
 			}
 			return message.util?.send(embed);
-		} catch {}
+		} catch {
+			return message.util?.send(MESSAGES.COMMANDS.MOD.HISTORY.NO_USER);
+		}
 	}
 }

--- a/src/bot/commands/mod/multiban.ts
+++ b/src/bot/commands/mod/multiban.ts
@@ -22,7 +22,6 @@ export default class MultiBanCommand extends Command {
 				Permissions.FLAGS.ATTACH_FILES,
 			],
 			ratelimit: 2,
-			flags: ['--report', '-r'],
 			channel: 'guild',
 			args: [
 				{

--- a/src/bot/commands/mod/multiban.ts
+++ b/src/bot/commands/mod/multiban.ts
@@ -11,7 +11,7 @@ export default class MultiBanCommand extends Command {
 			aliases: ['multiban', 'massban', 'nuke'],
 			description: {
 				content: MESSAGES.COMMANDS.MOD.MULTIBAN.DESCRIPTION,
-				usage: '<...user>',
+				usage: '<...user> [--report] [--nsfw] [--days=3]',
 				examples: ['81440962496172032 83886770768314368'],
 			},
 			category: 'mod',

--- a/src/bot/commands/tag/info.ts
+++ b/src/bot/commands/tag/info.ts
@@ -40,13 +40,19 @@ export default class TagInfoCommand extends Command {
 			lastModifiedBy = null;
 		}
 		const guild = this.client.guilds.cache.get(tag.guild);
-		const embed = new MessageEmbed().setColor(3447003).addField('❯ Name', tag.name);
+		const embed = new MessageEmbed().setColor(3447003).addField('❯ Name', `\`${tag.name}\``);
 		if (tag.templated) {
 			embed.addField('❯ Templated', '❗This tag is templated and resolves mentions and templates.');
 		}
+
+		const sinceCreationFormatted = moment.utc(tag.createdAt).fromNow();
+		const creationFormatted = moment.utc(tag.createdAt).format(DATE_FORMAT_WITH_SECONDS);
+		const sinceModifiedFormatted = moment.utc(tag.updatedAt).fromNow();
+		const modifiedFormatted = moment.utc(tag.updatedAt).format(DATE_FORMAT_WITH_SECONDS);
+
 		embed
-			.addField('❯ User', user ? `${user.tag} (ID: ${user.id})` : "Couldn't fetch user.")
-			.addField('❯ Guild', guild ? `${guild.name}` : "Couldn't fetch guild.")
+			.addField('❯ User', user ? `\`${user.tag}\` (${user.id})` : "Couldn't fetch user.")
+			.addField('❯ Guild', guild ? `\`${guild.name}\`` : "Couldn't fetch guild.")
 			.addField(
 				'❯ Aliases',
 				tag.aliases.length
@@ -56,13 +62,13 @@ export default class TagInfoCommand extends Command {
 							.join(', ')
 					: 'No aliases.',
 			)
-			.addField('❯ Uses', tag.uses)
-			.addField('❯ Created at', moment.utc(tag.createdAt).format(DATE_FORMAT_WITH_SECONDS))
-			.addField('❯ Modified at', moment.utc(tag.updatedAt).format(DATE_FORMAT_WITH_SECONDS));
+			.addField('❯ Uses', `${tag.uses}`)
+			.addField('❯ Created', `\`${creationFormatted} (UTC)\` (${sinceCreationFormatted})`)
+			.addField('❯ Last Modified', `\`${modifiedFormatted} (UTC)\` (${sinceModifiedFormatted})`);
 		if (lastModifiedBy) {
 			embed.addField(
 				'❯ Last modified by',
-				lastModifiedBy ? `${lastModifiedBy.tag} (ID: ${lastModifiedBy.id})` : "Couldn't fetch user.",
+				lastModifiedBy ? `\`${lastModifiedBy.tag}\` (${lastModifiedBy.id})` : "Couldn't fetch user.",
 			);
 		}
 

--- a/src/bot/commands/util/cybernuke.ts
+++ b/src/bot/commands/util/cybernuke.ts
@@ -56,6 +56,11 @@ export default class LaunchCybernukeCommand extends Command {
 					flag: ['--report', '-r'],
 				},
 				{
+					id: 'list',
+					match: 'flag',
+					flag: ['--list', '-ls', '-l'],
+				},
+				{
 					id: 'days',
 					type: 'integer',
 					match: 'option',
@@ -109,6 +114,21 @@ export default class LaunchCybernukeCommand extends Command {
 			);
 		}
 
+		if (list) {
+			await message.channel.send(
+				`${MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.CONFIRMATION(
+					message.author,
+					members.size,
+				)}\n${MESSAGES.COMMANDS.UTIL.CYBERNUKE.PARAMETERS(
+					`\`${nowFormatted} (UTC)\``,
+					`\`${joinCutoffFormatted} (UTC)\``,
+					`\`${ageCutoffFormatted} (UTC)\``,
+				)}\n• Projected targets:\n${members.map((m) => `\`${m.user.tag}\``).join(', ')}`,
+				{
+					split: true,
+				},
+			);
+		} else {
 		await message.util?.send(
 			`${MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.CONFIRMATION(
 				message.author,
@@ -119,6 +139,7 @@ export default class LaunchCybernukeCommand extends Command {
 				`\`${ageCutoffFormatted} (UTC)\``,
 			)}`,
 		);
+		}
 
 		const filter = (m: Message) =>
 			m.author.id === message.author.id && ['y', 'yes', 'n', 'no'].includes(m.content.toLowerCase());

--- a/src/bot/commands/util/cybernuke.ts
+++ b/src/bot/commands/util/cybernuke.ts
@@ -13,7 +13,7 @@ export default class LaunchCybernukeCommand extends Command {
 			aliases: ['cybernuke', 'launch-cybernuke'],
 			description: {
 				content: MESSAGES.COMMANDS.UTIL.CYBERNUKE.DESCRIPTION,
-				usage: '<join> <age>',
+				usage: '<join> <age> [--report] [--list] [--days=3] [--nsfw]',
 				examples: ['10 120'],
 			},
 			category: 'util',

--- a/src/bot/commands/util/cybernuke.ts
+++ b/src/bot/commands/util/cybernuke.ts
@@ -90,7 +90,7 @@ export default class LaunchCybernukeCommand extends Command {
 		days = Math.min(Math.max(days, 0), 7);
 
 		const guild = message.guild!;
-		await message.util?.send('Calculating targeting parameters for cybernuke...');
+		message.channel.startTyping();
 		const fetchedMembers = await guild.members.fetch();
 
 		const joinCutoff = Date.now() - join;
@@ -104,8 +104,9 @@ export default class LaunchCybernukeCommand extends Command {
 			(member) => (member.joinedTimestamp ?? 0) > joinCutoff && member.user.createdTimestamp > ageCutoff,
 		);
 
+		message.channel.stopTyping();
 		if (!members.size) {
-			return message.util?.send(
+			return message.channel.send(
 				`${MESSAGES.COMMANDS.UTIL.CYBERNUKE.FAIL.NO_MEMBERS}\n${MESSAGES.COMMANDS.UTIL.CYBERNUKE.PARAMETERS(
 					`\`${nowFormatted} (UTC)\``,
 					`\`${joinCutoffFormatted} (UTC)\``,
@@ -129,16 +130,16 @@ export default class LaunchCybernukeCommand extends Command {
 				},
 			);
 		} else {
-		await message.util?.send(
-			`${MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.CONFIRMATION(
-				message.author,
-				members.size,
-			)}\n${MESSAGES.COMMANDS.UTIL.CYBERNUKE.PARAMETERS(
-				`\`${nowFormatted} (UTC)\``,
-				`\`${joinCutoffFormatted} (UTC)\``,
-				`\`${ageCutoffFormatted} (UTC)\``,
-			)}`,
-		);
+			await message.util?.send(
+				`${MESSAGES.COMMANDS.UTIL.CYBERNUKE.PROMPT.CONFIRMATION(
+					message.author,
+					members.size,
+				)}\n${MESSAGES.COMMANDS.UTIL.CYBERNUKE.PARAMETERS(
+					`\`${nowFormatted} (UTC)\``,
+					`\`${joinCutoffFormatted} (UTC)\``,
+					`\`${ageCutoffFormatted} (UTC)\``,
+				)}`,
+			);
 		}
 
 		const filter = (m: Message) =>
@@ -152,6 +153,8 @@ export default class LaunchCybernukeCommand extends Command {
 				const fatalities: GuildMember[] = [];
 				const survivors: { member: GuildMember; error: Error }[] = [];
 				const promises: Promise<Message | void>[] = [];
+
+				message.channel.startTyping();
 
 				let i = 0;
 				for (const member of members.values()) {
@@ -234,6 +237,8 @@ export default class LaunchCybernukeCommand extends Command {
 			return message.channel.send(MESSAGES.COMMANDS.UTIL.CYBERNUKE.FAIL.CONFIRMATION);
 		} catch {
 			message.channel.send(MESSAGES.COMMANDS.UTIL.CYBERNUKE.FAIL.TIMEOUT);
+		} finally {
+			message.channel.stopTyping();
 		}
 
 		return null;

--- a/src/bot/commands/util/cybernuke.ts
+++ b/src/bot/commands/util/cybernuke.ts
@@ -17,6 +17,7 @@ export default class LaunchCybernukeCommand extends Command {
 				examples: ['10 120'],
 			},
 			category: 'util',
+			channel: 'guild',
 			userPermissions: [Permissions.FLAGS.MANAGE_GUILD],
 			clientPermissions: [Permissions.FLAGS.BAN_MEMBERS],
 			ratelimit: 2,

--- a/src/bot/listeners/client/moderation/guildMemberAdd.ts
+++ b/src/bot/listeners/client/moderation/guildMemberAdd.ts
@@ -87,10 +87,10 @@ export default class GuildMemberAddAntiraidListener extends Listener {
 					.setAuthor(MESSAGES.ANTIRAID.REASON)
 					.setDescription(
 						stripIndents`
-							**Member:** ${member.user.tag} (${member.user.id})
+							**Member:** \`${member.user.tag}\` (${member.user.id})
 							**Action:** ${mode.toLowerCase().replace(/(^|\s)\S/g, (t) => t.toUpperCase())}
-							**Created:** ${sinceCreationFormatted} (${creationFormatted})
-							**Joined:** ${sinceJoinFormatted} (${joinFormatted})
+							**Created:** \`${creationFormatted} (UTC)\` (${sinceCreationFormatted})
+							**Joined:** \`${joinFormatted} (UTC)\` (${sinceJoinFormatted})
 						`,
 					)
 					.setFooter(`Case ${totalCases}`)

--- a/src/bot/structures/case/actions/Action.ts
+++ b/src/bot/structures/case/actions/Action.ts
@@ -14,6 +14,9 @@ export interface ActionData {
 	days?: number;
 	duration?: number;
 	nsfw?: boolean;
+	skipPrompt?: boolean;
+	skipResponse?: boolean;
+	overrideColor?: number;
 }
 
 export default abstract class Action {
@@ -35,6 +38,12 @@ export default abstract class Action {
 
 	protected nsfw?: boolean;
 
+	protected skipPrompt?: boolean;
+
+	protected skipResponse?: boolean;
+
+	protected overrideColor?: number;
+
 	public constructor(protected action: ACTIONS, data: ActionData) {
 		this.client = data.message.client as YukikazeClient;
 		this.message = data.message;
@@ -45,6 +54,9 @@ export default abstract class Action {
 		this.days = data.days;
 		this.duration = data.duration;
 		this.nsfw = data.nsfw;
+		this.skipPrompt = data.skipPrompt;
+		this.skipResponse = data.skipResponse;
+		this.overrideColor = data.overrideColor;
 	}
 
 	protected get reason() {
@@ -80,6 +92,7 @@ export default abstract class Action {
 	}
 
 	protected get color() {
+		if (this.overrideColor) return this.overrideColor;
 		switch (this.action) {
 			case ACTIONS.BAN:
 				return COLORS.BAN;

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -564,7 +564,6 @@ export const MESSAGES = {
 
 			HISTORY: {
 				DESCRIPTION: 'Check the history of a member.',
-				NO_PERMISSION: 'you know, I know, we should just leave it at that.',
 			},
 
 			KICK: {

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -565,6 +565,7 @@ export const MESSAGES = {
 
 			HISTORY: {
 				DESCRIPTION: 'Check the history of a member.',
+				NO_USER: "I was looking everywhere, but i can't find this target!",
 			},
 
 			KICK: {

--- a/src/bot/util/constants.ts
+++ b/src/bot/util/constants.ts
@@ -19,6 +19,7 @@ export enum ACTIONS {
 export const MAX_TRUST_ACCOUNT_AGE = 1000 * 60 * 60 * 24 * 7 * 4;
 
 export const DATE_FORMAT_WITH_SECONDS = 'YYYY/MM/DD HH:mm:ss';
+export const DATE_FORMAT_DATE = 'YYYY/MM/DD';
 
 export const DATE_FORMAT_LOGFILE = 'YYYY-MM-DD_HH-mm-ss';
 

--- a/src/bot/util/graphQL.ts
+++ b/src/bot/util/graphQL.ts
@@ -81,6 +81,9 @@ export const GRAPHQL = {
 					targetId: { _eq: $targetId }
 				}) {
 					action
+					caseId
+					reason
+					createdAt
 				}
 			}
 		`,


### PR DESCRIPTION
- Improvements on various commands, streamlining embed designs
- escaping userinput with inline codeblocks where possible, to prevent it from growing out of the embeds boundaries if zalgo or other vertically or horizontally challenging characters are used
- userinfo: fetches members if needed and works with non-members
- history: now actually useful, restricted to moderation role only
- multiban and cybernuke now available with log setting nsfw
- cybernuke: add flag to list targets before execution
- use typing indicators for bulk commands instead of updating messages, split and send long member lists
- unify date formatting
- reminder that https://github.com/Naval-Base/yuudachi/pull/750 is still open


muterole-rolestate conflict: need to keep an eye on that one, as it's entirely not reproducible in sandboxed environments
