### PR TITLE
style(*): discord-api-types fun!

### DIFF
--- a/packages/api/src/api/Guilds.ts
+++ b/packages/api/src/api/Guilds.ts
@@ -1,6 +1,6 @@
 import { Case, CreateCase, UpdateCase, Lockdown, CreateLockdown, DeleteLockdown } from '@yuudachi/types';
 import { Constants } from '@yuudachi/core';
-import { RESTGetAPICurrentUserGuildsResult, RESTGetAPIGuildRolesResult } from 'discord-api-types';
+import { RESTGetAPICurrentUserGuildsResult, RESTGetAPIGuildRolesResult } from 'discord-api-types/v8';
 import API from '..';
 
 const { USER_ID_HEADER } = Constants;

--- a/src/api/src/managers/CaseLogManager.test.ts
+++ b/src/api/src/managers/CaseLogManager.test.ts
@@ -8,7 +8,7 @@ import { Tokens } from '@yuudachi/core';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 dayjs.extend(relativeTime);
-import { Routes } from 'discord-api-types';
+import { Routes } from 'discord-api-types/v8';
 
 import CaseLogManager from './CaseLogManager';
 import SettingsManager, { SettingsKeys } from './SettingsManager';

--- a/src/api/src/managers/CaseLogManager.ts
+++ b/src/api/src/managers/CaseLogManager.ts
@@ -1,4 +1,4 @@
-import { RESTGetAPIGuildRolesResult, APIMessage, APIUser, APIEmbed, Routes } from 'discord-api-types';
+import { RESTGetAPIGuildRolesResult, APIMessage, APIUser, APIEmbed, Routes } from 'discord-api-types/v8';
 import { CaseAction } from '@yuudachi/types';
 import { stripIndents } from 'common-tags';
 import { inject, injectable } from 'tsyringe';

--- a/src/api/src/managers/CaseManager.test.ts
+++ b/src/api/src/managers/CaseManager.test.ts
@@ -5,7 +5,7 @@ import { Case, CaseAction } from '@yuudachi/types';
 import postgres, { Sql } from 'postgres';
 import { container } from 'tsyringe';
 import { Tokens } from '@yuudachi/core';
-import { Routes } from 'discord-api-types';
+import { Routes } from 'discord-api-types/v8';
 
 import CaseManager from './CaseManager';
 

--- a/src/api/src/managers/CaseManager.ts
+++ b/src/api/src/managers/CaseManager.ts
@@ -1,4 +1,4 @@
-import { APIUser, Routes } from 'discord-api-types';
+import { APIUser, Routes } from 'discord-api-types/v8';
 import { Sql } from 'postgres';
 import Rest from '@yuudachi/rest';
 import { Case, CaseAction } from '@yuudachi/types';

--- a/src/api/src/managers/LockdownManager.test.ts
+++ b/src/api/src/managers/LockdownManager.test.ts
@@ -5,7 +5,7 @@ import { Lockdown } from '@yuudachi/types';
 import postgres, { Sql } from 'postgres';
 import { container } from 'tsyringe';
 import { Tokens } from '@yuudachi/core';
-import { OverwriteType, PermissionFlagsBits, Routes } from 'discord-api-types';
+import { OverwriteType, PermissionFlagsBits, Routes } from 'discord-api-types/v8';
 
 import LockdownManager from './LockdownManager';
 import SettingsManager, { SettingsKeys } from './SettingsManager';

--- a/src/api/src/managers/LockdownManager.ts
+++ b/src/api/src/managers/LockdownManager.ts
@@ -3,7 +3,7 @@ import Rest from '@yuudachi/rest';
 import { Lockdown } from '@yuudachi/types';
 import { inject, injectable } from 'tsyringe';
 import { Tokens } from '@yuudachi/core';
-import { APIChannel, APIOverwrite, APIUser, OverwriteType, PermissionFlagsBits, Routes } from 'discord-api-types';
+import { APIChannel, APIOverwrite, APIUser, OverwriteType, PermissionFlagsBits, Routes } from 'discord-api-types/v8';
 import SettingsManager from './SettingsManager';
 
 const { kSQL } = Tokens;

--- a/src/api/src/routes/guilds/[guildId]/roles/get.ts
+++ b/src/api/src/routes/guilds/[guildId]/roles/get.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'polka';
 import { injectable } from 'tsyringe';
 import Rest, { HttpException } from '@yuudachi/rest';
 import { Route } from '@yuudachi/http';
-import { RESTGetAPIGuildRolesResult } from 'discord-api-types';
+import { RESTGetAPIGuildRolesResult } from 'discord-api-types/v8';
 import { forbidden, notFound } from '@hapi/boom';
 
 @injectable()

--- a/src/api/src/routes/guilds/get.ts
+++ b/src/api/src/routes/guilds/get.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'polka';
 import { injectable } from 'tsyringe';
 import Rest, { HttpException } from '@yuudachi/rest';
 import { Route } from '@yuudachi/http';
-import { RESTGetAPICurrentUserGuildsResult } from 'discord-api-types';
+import { RESTGetAPICurrentUserGuildsResult } from 'discord-api-types/v8';
 import { forbidden, notFound } from '@hapi/boom';
 
 @injectable()

--- a/src/api/src/routes/guilds/oauth/get.ts
+++ b/src/api/src/routes/guilds/oauth/get.ts
@@ -4,7 +4,7 @@ import { Sql } from 'postgres';
 import fetch from 'node-fetch';
 import { Route } from '@yuudachi/http';
 import { Constants, Tokens } from '@yuudachi/core';
-import { RESTGetAPICurrentUserGuildsResult } from 'discord-api-types';
+import { RESTGetAPICurrentUserGuildsResult } from 'discord-api-types/v8';
 import { unauthorized } from '@hapi/boom';
 
 const { kSQL } = Tokens;

--- a/src/auth/src/routes/auth/refresh/get.ts
+++ b/src/auth/src/routes/auth/refresh/get.ts
@@ -21,7 +21,7 @@ export default class TokenRefreshRoute extends Route {
 
 		let credentials: AuthCredentials;
 		try {
-			credentials = await this.authManager.refresh(req.auth!.token, cookies.refresh_token);
+			credentials = await this.authManager.refresh(req.auth.token, cookies.refresh_token);
 		} catch {
 			return next(unauthorized());
 		}

--- a/src/handler/src/Command.ts
+++ b/src/handler/src/Command.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage, APIApplicationCommandInteractionDataOption } from 'discord-api-types';
+import { APIInteraction, APIMessage, APIApplicationCommandInteractionDataOption } from 'discord-api-types/v8';
 import { Args } from 'lexure';
 import { basename, extname } from 'path';
 import { CommandModules } from './Constants';

--- a/src/handler/src/commands/config/config.ts
+++ b/src/handler/src/commands/config/config.ts
@@ -1,5 +1,5 @@
 import { injectable, inject } from 'tsyringe';
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Args } from 'lexure';
 import { Sql } from 'postgres';
 import i18next from 'i18next';

--- a/src/handler/src/commands/config/debug.ts
+++ b/src/handler/src/commands/config/debug.ts
@@ -1,5 +1,5 @@
 import { injectable } from 'tsyringe';
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Args } from 'lexure';
 import i18next from 'i18next';
 

--- a/src/handler/src/commands/config/sub/debug/refresh.ts
+++ b/src/handler/src/commands/config/sub/debug/refresh.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage, Routes } from 'discord-api-types';
+import { APIInteraction, APIMessage, Routes } from 'discord-api-types/v8';
 import { Args } from 'lexure';
 import i18next from 'i18next';
 import { container } from 'tsyringe';

--- a/src/handler/src/commands/documentation/docs.ts
+++ b/src/handler/src/commands/documentation/docs.ts
@@ -1,5 +1,5 @@
 import { injectable } from 'tsyringe';
-import { APIMessage } from 'discord-api-types';
+import { APIMessage } from 'discord-api-types/v8';
 import { Args, joinTokens } from 'lexure';
 import Rest from '@yuudachi/rest';
 import i18next from 'i18next';

--- a/src/handler/src/commands/github/github.ts
+++ b/src/handler/src/commands/github/github.ts
@@ -1,6 +1,6 @@
 import { Args } from 'lexure';
 import { injectable, inject } from 'tsyringe';
-import { APIMessage } from 'discord-api-types';
+import { APIMessage } from 'discord-api-types/v8';
 import { Sql } from 'postgres';
 import i18next from 'i18next';
 import { Tokens } from '@yuudachi/core';

--- a/src/handler/src/commands/github/sub/alias.ts
+++ b/src/handler/src/commands/github/sub/alias.ts
@@ -1,4 +1,4 @@
-import { APIMessage, Routes } from 'discord-api-types';
+import { APIMessage, Routes } from 'discord-api-types/v8';
 import { Args } from 'lexure';
 import { Sql } from 'postgres';
 import i18next from 'i18next';

--- a/src/handler/src/commands/github/sub/commit.ts
+++ b/src/handler/src/commands/github/sub/commit.ts
@@ -1,4 +1,4 @@
-import { APIMessage, APIEmbed } from 'discord-api-types';
+import { APIMessage, APIEmbed } from 'discord-api-types/v8';
 import Rest from '@yuudachi/rest';
 import i18next from 'i18next';
 import fetch from 'node-fetch';

--- a/src/handler/src/commands/github/sub/issue-pr.ts
+++ b/src/handler/src/commands/github/sub/issue-pr.ts
@@ -1,4 +1,4 @@
-import { APIMessage, APIEmbed } from 'discord-api-types';
+import { APIMessage, APIEmbed } from 'discord-api-types/v8';
 import fetch from 'node-fetch';
 import i18next from 'i18next';
 import Rest from '@yuudachi/rest';

--- a/src/handler/src/commands/moderation/ban.ts
+++ b/src/handler/src/commands/moderation/ban.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import API, { HttpException } from '@yuudachi/api';
 import { CaseAction } from '@yuudachi/types';
 import i18next from 'i18next';

--- a/src/handler/src/commands/moderation/duration.ts
+++ b/src/handler/src/commands/moderation/duration.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import API from '@yuudachi/api';
 import i18next from 'i18next';
 import { Args, joinTokens } from 'lexure';

--- a/src/handler/src/commands/moderation/history.ts
+++ b/src/handler/src/commands/moderation/history.ts
@@ -1,4 +1,4 @@
-import { APIMessage, APIEmbed, APIGuildMember, APIUser, APIInteraction } from 'discord-api-types';
+import { APIMessage, APIEmbed, APIGuildMember, APIUser, APIInteraction } from 'discord-api-types/v8';
 import Rest from '@yuudachi/rest';
 import i18next from 'i18next';
 import { Args } from 'lexure';

--- a/src/handler/src/commands/moderation/kick.ts
+++ b/src/handler/src/commands/moderation/kick.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import API, { HttpException } from '@yuudachi/api';
 import { CaseAction } from '@yuudachi/types';
 import i18next from 'i18next';

--- a/src/handler/src/commands/moderation/lockdown.ts
+++ b/src/handler/src/commands/moderation/lockdown.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import i18next from 'i18next';
 import { Args, joinTokens, ok } from 'lexure';
 import { injectable } from 'tsyringe';

--- a/src/handler/src/commands/moderation/reason.ts
+++ b/src/handler/src/commands/moderation/reason.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import API from '@yuudachi/api';
 import i18next from 'i18next';
 import { Args, joinTokens } from 'lexure';

--- a/src/handler/src/commands/moderation/reference.ts
+++ b/src/handler/src/commands/moderation/reference.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import API from '@yuudachi/api';
 import i18next from 'i18next';
 import { Args, joinTokens } from 'lexure';

--- a/src/handler/src/commands/moderation/restrict.ts
+++ b/src/handler/src/commands/moderation/restrict.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import i18next from 'i18next';
 import { Args, joinTokens, Ok } from 'lexure';
 import { injectable } from 'tsyringe';

--- a/src/handler/src/commands/moderation/softban.ts
+++ b/src/handler/src/commands/moderation/softban.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import API, { HttpException } from '@yuudachi/api';
 import { CaseAction } from '@yuudachi/types';
 import i18next from 'i18next';

--- a/src/handler/src/commands/moderation/sub/lockdown/lift.ts
+++ b/src/handler/src/commands/moderation/sub/lockdown/lift.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Ok } from 'lexure';
 import i18next from 'i18next';
 import API, { HttpException } from '@yuudachi/api';

--- a/src/handler/src/commands/moderation/sub/lockdown/lock.ts
+++ b/src/handler/src/commands/moderation/sub/lockdown/lock.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage, Routes } from 'discord-api-types';
+import { APIInteraction, APIMessage, Routes } from 'discord-api-types/v8';
 import { Ok } from 'lexure';
 import i18next from 'i18next';
 import ms from '@naval-base/ms';

--- a/src/handler/src/commands/moderation/sub/restrict/embed.ts
+++ b/src/handler/src/commands/moderation/sub/restrict/embed.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Ok } from 'lexure';
 import i18next from 'i18next';
 import API, { HttpException } from '@yuudachi/api';

--- a/src/handler/src/commands/moderation/sub/restrict/emoji.ts
+++ b/src/handler/src/commands/moderation/sub/restrict/emoji.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Ok } from 'lexure';
 import i18next from 'i18next';
 import API, { HttpException } from '@yuudachi/api';

--- a/src/handler/src/commands/moderation/sub/restrict/mute.ts
+++ b/src/handler/src/commands/moderation/sub/restrict/mute.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Ok } from 'lexure';
 import i18next from 'i18next';
 import API, { HttpException } from '@yuudachi/api';

--- a/src/handler/src/commands/moderation/sub/restrict/react.ts
+++ b/src/handler/src/commands/moderation/sub/restrict/react.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Ok } from 'lexure';
 import i18next from 'i18next';
 import API, { HttpException } from '@yuudachi/api';

--- a/src/handler/src/commands/moderation/sub/restrict/tag.ts
+++ b/src/handler/src/commands/moderation/sub/restrict/tag.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Ok } from 'lexure';
 import i18next from 'i18next';
 import API, { HttpException } from '@yuudachi/api';

--- a/src/handler/src/commands/moderation/sub/restrict/unrole.ts
+++ b/src/handler/src/commands/moderation/sub/restrict/unrole.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import i18next from 'i18next';
 import API, { HttpException } from '@yuudachi/api';
 import { container } from 'tsyringe';

--- a/src/handler/src/commands/moderation/unban.ts
+++ b/src/handler/src/commands/moderation/unban.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import API, { HttpException } from '@yuudachi/api';
 import { CaseAction } from '@yuudachi/types';
 import i18next from 'i18next';

--- a/src/handler/src/commands/moderation/warn.ts
+++ b/src/handler/src/commands/moderation/warn.ts
@@ -1,4 +1,4 @@
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import API, { HttpException } from '@yuudachi/api';
 import { CaseAction } from '@yuudachi/types';
 import i18next from 'i18next';

--- a/src/handler/src/commands/tags/sub/search.ts
+++ b/src/handler/src/commands/tags/sub/search.ts
@@ -1,5 +1,5 @@
 import { Args } from 'lexure';
-import { APIMessage } from 'discord-api-types';
+import { APIMessage } from 'discord-api-types/v8';
 import { Sql } from 'postgres';
 import i18next from 'i18next';
 import Rest from '@yuudachi/rest';

--- a/src/handler/src/commands/tags/tag.ts
+++ b/src/handler/src/commands/tags/tag.ts
@@ -1,5 +1,5 @@
 import { injectable, inject } from 'tsyringe';
-import { APIMessage } from 'discord-api-types';
+import { APIMessage } from 'discord-api-types/v8';
 import { Args, joinTokens } from 'lexure';
 import Rest from '@yuudachi/rest';
 import { Sql } from 'postgres';

--- a/src/handler/src/commands/util/ping.ts
+++ b/src/handler/src/commands/util/ping.ts
@@ -1,5 +1,5 @@
 import { injectable } from 'tsyringe';
-import { APIInteraction, APIMessage } from 'discord-api-types';
+import { APIInteraction, APIMessage } from 'discord-api-types/v8';
 import { Args } from 'lexure';
 import i18next from 'i18next';
 

--- a/src/handler/src/parsers/interaction.ts
+++ b/src/handler/src/parsers/interaction.ts
@@ -1,4 +1,4 @@
-import { APIApplicationCommandInteractionDataOption } from 'discord-api-types';
+import { APIApplicationCommandInteractionDataOption } from 'discord-api-types/v8';
 import { ParserOutput } from 'lexure';
 
 function parseOptions(

--- a/src/handler/src/util/edit.test.ts
+++ b/src/handler/src/util/edit.test.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata';
 import Rest from '@yuudachi/rest';
 import { container } from 'tsyringe';
 import { edit } from './edit';
-import { Routes } from 'discord-api-types';
+import { Routes } from 'discord-api-types/v8';
 
 jest.mock('@yuudachi/rest');
 

--- a/src/handler/src/util/edit.ts
+++ b/src/handler/src/util/edit.ts
@@ -5,7 +5,7 @@ import {
 	APIInteractionApplicationCommandCallbackData,
 	RESTPostAPIChannelMessageJSONBody,
 	Routes,
-} from 'discord-api-types';
+} from 'discord-api-types/v8';
 import Rest from '@yuudachi/rest';
 import { container } from 'tsyringe';
 

--- a/src/handler/src/util/embed.ts
+++ b/src/handler/src/util/embed.ts
@@ -1,4 +1,4 @@
-import { APIEmbed, APIEmbedField } from 'discord-api-types';
+import { APIEmbed, APIEmbedField } from 'discord-api-types/v8';
 import {
 	EMBED_AUTHOR_NAME_LIMIT,
 	EMBED_DESCRIPTION_LIMIT,

--- a/src/handler/src/util/send.test.ts
+++ b/src/handler/src/util/send.test.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata';
 import Rest from '@yuudachi/rest';
 import { container } from 'tsyringe';
 import { send } from './send';
-import { Routes } from 'discord-api-types';
+import { Routes } from 'discord-api-types/v8';
 
 jest.mock('@yuudachi/rest');
 

--- a/src/handler/src/util/send.ts
+++ b/src/handler/src/util/send.ts
@@ -5,7 +5,7 @@ import {
 	APIInteractionApplicationCommandCallbackData,
 	RESTPostAPIChannelMessageJSONBody,
 	Routes,
-} from 'discord-api-types';
+} from 'discord-api-types/v8';
 import Rest from '@yuudachi/rest';
 import { container } from 'tsyringe';
 

--- a/src/website/src/components/GuildDisplay.tsx
+++ b/src/website/src/components/GuildDisplay.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 import { Grid, Heading } from '@chakra-ui/react';
-import { RESTAPIPartialCurrentUserGuild, RESTGetAPICurrentUserGuildsResult } from 'discord-api-types';
+import { RESTAPIPartialCurrentUserGuild, RESTGetAPICurrentUserGuildsResult } from 'discord-api-types/v8';
 
 const GuildIcon = dynamic(() => import('~/components/GuildIcon'));
 

--- a/src/website/src/components/GuildIcon.tsx
+++ b/src/website/src/components/GuildIcon.tsx
@@ -1,5 +1,5 @@
 import { Img } from '@chakra-ui/react';
-import { RESTAPIPartialCurrentUserGuild } from 'discord-api-types';
+import { RESTAPIPartialCurrentUserGuild } from 'discord-api-types/v8';
 
 const GuildIcon = ({ guild }: { guild?: RESTAPIPartialCurrentUserGuild }) =>
 	guild?.icon ? (

--- a/src/website/src/components/GuildSettingsFormSelectControl.tsx
+++ b/src/website/src/components/GuildSettingsFormSelectControl.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormLabel, Select } from '@chakra-ui/react';
 import { UseFormMethods, Controller } from 'react-hook-form';
-import { APIRole } from 'discord-api-types';
+import { APIRole } from 'discord-api-types/v8';
 
 import { GraphQLGuildSettings } from '~/interfaces/GuildSettings';
 

--- a/src/website/src/interfaces/Guild.ts
+++ b/src/website/src/interfaces/Guild.ts
@@ -1,4 +1,4 @@
-import { RESTAPIPartialCurrentUserGuild, RESTGetAPICurrentUserGuildsResult } from 'discord-api-types';
+import { RESTAPIPartialCurrentUserGuild, RESTGetAPICurrentUserGuildsResult } from 'discord-api-types/v8';
 
 export interface GraphQLOAuthGuilds {
 	data: {

--- a/src/website/src/interfaces/GuildRole.ts
+++ b/src/website/src/interfaces/GuildRole.ts
@@ -1,4 +1,4 @@
-import { APIRole } from 'discord-api-types';
+import { APIRole } from 'discord-api-types/v8';
 
 export interface GraphQLGuildRoles {
 	data: {


### PR DESCRIPTION
This PR:
- switches event definitions from string to using constants (9a069c0)
- imports `discord-api-types` using a version [as suggested](https://github.com/discordjs/discord-api-types/blob/main/README.md#usage)* (6e00758)

<details>
<summary>*</summary>
> We <b>strongly recommend</b> you use a version when importing this module! This will prevent breaking changes when updating the module.
</details>