### PR TITLE
chore(github): update github commands

### DIFF
--- a/src/bot/commands/github/issue-pr.ts
+++ b/src/bot/commands/github/issue-pr.ts
@@ -14,7 +14,7 @@ export default class GitHubPROrIssueCommand extends Command {
 				usage: '<pr/issue>',
 				examples: ['1', '24', '100'],
 			},
-			regex: /\b(g|djs|commando|guide|rpc|collection)#(\d+)/i,
+			regex: /\b(g|djs|commando|guide|rpc|collection|opus)#(\d+)/i,
 			category: 'github',
 			channel: 'guild',
 			clientPermissions: [Permissions.FLAGS.EMBED_LINKS],
@@ -64,6 +64,9 @@ export default class GitHubPROrIssueCommand extends Command {
 					owner = 'discordjs';
 					repo = 'collection';
 					break;
+				case 'opus':
+					owner = 'discordjs';
+					repo = 'opus';
 				default:
 					return message.util?.reply('No u.');
 			}
@@ -161,7 +164,7 @@ export default class GitHubPROrIssueCommand extends Command {
 			.setThumbnail(d.author?.avatarUrl ?? '')
 			.setTimestamp(new Date(d.publishedAt));
 		if (repo && !['guide'].includes(repo) && d.commits) {
-			embed.addField('Install with', `\`npm i ${owner}/${repo}#${d.commits.nodes[0].commit.oid.substring(0, 12)}\``);
+			embed.addField('Install with', `\`npm i ${owner}/${repo}#${d.number}/head\``);
 		}
 
 		if (

--- a/src/bot/commands/github/search.ts
+++ b/src/bot/commands/github/search.ts
@@ -210,7 +210,7 @@ export default class GitHubSearchCommand extends Command {
 		if (d.commits) {
 			embed.addField(
 				'Install with',
-				`\`npm i discordjs/discord.js#${d.commits.nodes[0].commit.oid.substring(0, 12)}\``,
+				`\`npm i ${owner}/${repository}#${d.commits.nodes[0].commit.oid.substring(0, 12)}\``,
 			);
 		}
 


### PR DESCRIPTION
This PR:
* adds opus to the `issue-pr` regex
* fixes the 'Install With' field on the `search` command to template the repo owner & name
* switches to `owner/repo#pr/head` to install a PR instead of the latest commit