### PR TITLE
refactor: use `@discordjs/builders` for slash command objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"version": "3.0.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
+				"@discordjs/builders": "^0.4.0",
 				"@discordjs/rest": "^0.1.0-canary.0",
 				"@elastic/ecs-pino-format": "^1.2.0",
 				"@naval-base/ms": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	"license": "AGPL-3.0",
 	"private": true,
 	"dependencies": {
+		"@discordjs/builders": "^0.4.0",
 		"@discordjs/rest": "^0.1.0-canary.0",
 		"@elastic/ecs-pino-format": "^1.2.0",
 		"@naval-base/ms": "^3.1.0",

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -30,30 +30,30 @@ const rest = new REST({ version: '9' }).setToken(process.env.DISCORD_TOKEN!);
 try {
 	console.log('Start refreshing interaction (/) commands.');
 
+	const moderationCommands = [
+		AntiRaidNukeCommand,
+		BanCommand,
+		DurationCommand,
+		HistoryCommand,
+		KickCommand,
+		ReasonCommand,
+		ReferenceCommand,
+		RestrictCommand,
+		SoftbanCommand,
+		UnbanCommand,
+		WarnCommand,
+		LockdownCommand,
+	].map((cmd) => ({ ...cmd.toJSON(), default_permission: false }));
+
+	const utilityCommands = [PingCommand].map((cmd) => cmd.toJSON());
+
 	const commands = (await rest.put(
 		Routes.applicationGuildCommands(
 			process.env.DISCORD_CLIENT_ID as Snowflake,
 			process.env.DISCORD_GUILD_ID as Snowflake,
 		),
 		{
-			body: [
-				// Moderation
-				AntiRaidNukeCommand,
-				BanCommand,
-				DurationCommand,
-				HistoryCommand,
-				KickCommand,
-				ReasonCommand,
-				ReferenceCommand,
-				RestrictCommand,
-				SoftbanCommand,
-				UnbanCommand,
-				WarnCommand,
-				LockdownCommand,
-
-				// Utility
-				PingCommand,
-			],
+			body: [...utilityCommands, ...moderationCommands],
 		},
 	)) as RESTGetAPIApplicationGuildCommandsResult;
 

--- a/src/interactions/moderation/anti-raid-nuke.ts
+++ b/src/interactions/moderation/anti-raid-nuke.ts
@@ -1,41 +1,34 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const AntiRaidNukeCommand = {
-	name: 'anti-raid-nuke',
-	description: 'Bans all members that have joined recently, with new accounts',
-	options: [
-		{
-			name: 'join',
-			description: 'How old should a member be for the cybernuke to ignore them (server join date)?',
-			type: ApplicationCommandOptionType.String,
-			required: true,
-		},
-		{
-			name: 'age',
-			description: "How old should a member's account be for the cybernuke to ignore them (account age)?",
-			type: ApplicationCommandOptionType.String,
-			required: true,
-		},
-		{
-			name: 'reason',
-			description: 'The reason of this action',
-			type: ApplicationCommandOptionType.String,
-		},
-		{
-			name: 'days',
-			description: 'The amount of days to deleted messages from',
-			type: ApplicationCommandOptionType.Integer,
-			choices: [
-				{ name: '0 days (default)', value: 0 },
-				{ name: '1 day', value: 1 },
-				{ name: '2 days', value: 2 },
-				{ name: '3 days', value: 3 },
-				{ name: '4 days', value: 4 },
-				{ name: '5 days', value: 5 },
-				{ name: '6 days', value: 6 },
-				{ name: '7 days', value: 7 },
-			],
-		},
-	],
-	default_permission: false,
-} as const;
+export const AntiRaidNukeCommand = new SlashCommandBuilder()
+	.setName('anti-raid-nuke')
+	.setDescription('Bans all members that have joined recently, with new accounts')
+	.addStringOption((opt) =>
+		opt
+			.setName('join')
+			.setDescription('How old should a member be for the cybernuke to ignore them (server join date)?')
+			.setRequired(true),
+	)
+	.addStringOption((opt) =>
+		opt
+			.setName('age')
+			.setDescription("How old should a member's account be for the cybernuke to ignore them (account age)?")
+			.setRequired(true),
+	)
+	.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+	.addIntegerOption((opt) =>
+		opt
+			.setName('days')
+			.setDescription('The amount of days to deleted messages from')
+			.setRequired(false)
+			.addChoices([
+				['0 days (default)', 0],
+				['1 day', 1],
+				['2 days', 2],
+				['3 days', 3],
+				['4 days', 4],
+				['5 days', 5],
+				['6 days', 6],
+				['7 days', 7],
+			]),
+	);

--- a/src/interactions/moderation/ban.ts
+++ b/src/interactions/moderation/ban.ts
@@ -1,40 +1,24 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const BanCommand = {
-	name: 'ban',
-	description: 'Ban a member of(f) this guild',
-	options: [
-		{
-			name: 'user',
-			description: 'The user to action',
-			type: ApplicationCommandOptionType.User,
-			required: true,
-		},
-		{
-			name: 'reason',
-			description: 'The reason of this action',
-			type: ApplicationCommandOptionType.String,
-		},
-		{
-			name: 'days',
-			description: 'The amount of days to deleted messages from',
-			type: ApplicationCommandOptionType.Integer,
-			choices: [
-				{ name: '0 days (default)', value: 0 },
-				{ name: '1 day', value: 1 },
-				{ name: '2 days', value: 2 },
-				{ name: '3 days', value: 3 },
-				{ name: '4 days', value: 4 },
-				{ name: '5 days', value: 5 },
-				{ name: '6 days', value: 6 },
-				{ name: '7 days', value: 7 },
-			],
-		},
-		{
-			name: 'reference',
-			description: 'The reference case',
-			type: ApplicationCommandOptionType.Integer,
-		},
-	],
-	default_permission: false,
-} as const;
+export const BanCommand = new SlashCommandBuilder()
+	.setName('ban')
+	.setDescription('Ban a member of(f) this guild')
+	.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+	.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+	.addIntegerOption((opt) =>
+		opt
+			.setName('days')
+			.setDescription('The amount of days to deleted messages from')
+			.setRequired(false)
+			.addChoices([
+				['0 days (default)', 0],
+				['1 day', 1],
+				['2 days', 2],
+				['3 days', 3],
+				['4 days', 4],
+				['5 days', 5],
+				['6 days', 6],
+				['7 days', 7],
+			]),
+	)
+	.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false));

--- a/src/interactions/moderation/duration.ts
+++ b/src/interactions/moderation/duration.ts
@@ -1,30 +1,21 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const DurationCommand = {
-	name: 'duration',
-	description: 'Change the duration of a timed action',
-	options: [
-		{
-			name: 'case',
-			description: 'The case to look up',
-			type: ApplicationCommandOptionType.Integer,
-			required: true,
-		},
-		{
-			name: 'duration',
-			description: 'The duration',
-			type: ApplicationCommandOptionType.String,
-			choices: [
-				{ name: '3 hours', value: '3h' },
-				{ name: '6 hours', value: '6h' },
-				{ name: '12 hours', value: '12h' },
-				{ name: '1 day', value: '1d' },
-				{ name: '2 days', value: '2d' },
-				{ name: '3 days', value: '3d' },
-				{ name: '7 days', value: '7d' },
-			],
-			required: true,
-		},
-	],
-	default_permission: false,
-} as const;
+export const DurationCommand = new SlashCommandBuilder()
+	.setName('duration')
+	.setDescription('Change the duration of a timed action')
+	.addIntegerOption((opt) => opt.setName('case').setDescription('The case to look up').setRequired(true))
+	.addStringOption((opt) =>
+		opt
+			.setName('duration')
+			.setDescription('The duration')
+			.setRequired(true)
+			.addChoices([
+				['3 hours', '3h'],
+				['6 hours', '6h'],
+				['12 hours', '12h'],
+				['1 day', '1d'],
+				['2 days', '2d'],
+				['3 days', '3d'],
+				['7 days', '7d'],
+			]),
+	);

--- a/src/interactions/moderation/history.ts
+++ b/src/interactions/moderation/history.ts
@@ -1,20 +1,7 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const HistoryCommand = {
-	name: 'history',
-	description: 'Look up a users moderative history',
-	options: [
-		{
-			name: 'user',
-			description: 'The user to look up',
-			type: ApplicationCommandOptionType.User,
-			required: true,
-		},
-		{
-			name: 'hide',
-			description: 'Hides the output',
-			type: ApplicationCommandOptionType.Boolean,
-		},
-	],
-	default_permission: false,
-} as const;
+export const HistoryCommand = new SlashCommandBuilder()
+	.setName('history')
+	.setDescription('Look up a users moderative history')
+	.addUserOption((opt) => opt.setName('user').setDescription('The user to look up').setRequired(true))
+	.addBooleanOption((opt) => opt.setName('hide').setDescription('Hides the output').setRequired(false));

--- a/src/interactions/moderation/kick.ts
+++ b/src/interactions/moderation/kick.ts
@@ -1,25 +1,8 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const KickCommand = {
-	name: 'kick',
-	description: 'Kick a member of(f) this guild',
-	options: [
-		{
-			name: 'user',
-			description: 'The user to action',
-			type: ApplicationCommandOptionType.User,
-			required: true,
-		},
-		{
-			name: 'reason',
-			description: 'The reason of this action',
-			type: ApplicationCommandOptionType.String,
-		},
-		{
-			name: 'reference',
-			description: 'The reference case',
-			type: ApplicationCommandOptionType.Integer,
-		},
-	],
-	default_permission: false,
-} as const;
+export const KickCommand = new SlashCommandBuilder()
+	.setName('kick')
+	.setDescription('Kick a member of(f) this guild')
+	.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+	.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+	.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false));

--- a/src/interactions/moderation/lockdown.ts
+++ b/src/interactions/moderation/lockdown.ts
@@ -1,53 +1,35 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const LockdownCommand = {
-	name: 'lockdown',
-	description: 'Execute or lift a lockdown on a text channel',
-	options: [
-		{
-			name: 'lock',
-			description: 'Execute a lockdown on a text channel',
-			type: ApplicationCommandOptionType.Subcommand,
-			options: [
-				{
-					name: 'duration',
-					description: 'The duration',
-					type: ApplicationCommandOptionType.String,
-					choices: [
-						{ name: '1 hour', value: '1h' },
-						{ name: '3 hours', value: '3h' },
-						{ name: '6 hours', value: '6h' },
-						{ name: '12 hours', value: '12h' },
-						{ name: '1 day', value: '1d' },
-						{ name: '2 days', value: '2d' },
-						{ name: '3 days', value: '3d' },
-					],
-					required: true,
-				},
-				{
-					name: 'channel',
-					description: 'The channel to lock',
-					type: ApplicationCommandOptionType.Channel,
-				},
-				{
-					name: 'reason',
-					description: 'The reason of this lockdown',
-					type: ApplicationCommandOptionType.String,
-				},
-			],
-		},
-		{
-			name: 'lift',
-			description: 'Lift a lockdown on a text channel',
-			type: ApplicationCommandOptionType.Subcommand,
-			options: [
-				{
-					name: 'channel',
-					description: 'The channel to lift the lock',
-					type: ApplicationCommandOptionType.Channel,
-				},
-			],
-		},
-	],
-	default_permission: false,
-} as const;
+export const LockdownCommand = new SlashCommandBuilder()
+	.setName('lockdown')
+	.setDescription('Execute or lift a lockdown on a text channel')
+	.addSubcommand((sub) =>
+		sub
+			.setName('lock')
+			.setDescription('Execute a lockdown on a text channel')
+			.addStringOption((opt) =>
+				opt
+					.setName('duration')
+					.setDescription('The duration')
+					.setRequired(true)
+					.addChoices([
+						['1 hour', '1h'],
+						['3 hours', '3h'],
+						['6 hours', '6h'],
+						['12 hours', '12h'],
+						['1 day', '1d'],
+						['2 days', '2d'],
+						['3 days', '3d'],
+					]),
+			)
+			.addChannelOption((opt) => opt.setName('channel').setDescription('The channel to lock').setRequired(false))
+			.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this lockdown').setRequired(false)),
+	)
+	.addSubcommand((sub) =>
+		sub
+			.setName('lift')
+			.setDescription('Lift a lockdown on a text channel')
+			.addChannelOption((opt) =>
+				opt.setName('channel').setDescription('The channel to lift the lock').setRequired(false),
+			),
+	);

--- a/src/interactions/moderation/reason.ts
+++ b/src/interactions/moderation/reason.ts
@@ -1,21 +1,7 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const ReasonCommand = {
-	name: 'reason',
-	description: 'Change the reason of an action',
-	options: [
-		{
-			name: 'case',
-			description: 'The case to look up',
-			type: ApplicationCommandOptionType.Integer,
-			required: true,
-		},
-		{
-			name: 'reason',
-			description: 'The reason',
-			type: ApplicationCommandOptionType.String,
-			required: true,
-		},
-	],
-	default_permission: false,
-} as const;
+export const ReasonCommand = new SlashCommandBuilder()
+	.setName('reason')
+	.setDescription('Change the reason of an action')
+	.addIntegerOption((opt) => opt.setName('case').setDescription('The case to look up').setRequired(true))
+	.addStringOption((opt) => opt.setName('reason').setDescription('The reason').setRequired(true));

--- a/src/interactions/moderation/reference.ts
+++ b/src/interactions/moderation/reference.ts
@@ -1,21 +1,7 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const ReferenceCommand = {
-	name: 'reference',
-	description: 'Change the reference of an action',
-	options: [
-		{
-			name: 'case',
-			description: 'The case to look up',
-			type: ApplicationCommandOptionType.Integer,
-			required: true,
-		},
-		{
-			name: 'reference',
-			description: 'The reference case',
-			type: ApplicationCommandOptionType.Integer,
-			required: true,
-		},
-	],
-	default_permission: false,
-} as const;
+export const ReferenceCommand = new SlashCommandBuilder()
+	.setName('reference')
+	.setDescription('Change the reference of an action')
+	.addIntegerOption((opt) => opt.setName('case').setDescription('The case to look up').setRequired(true))
+	.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(true));

--- a/src/interactions/moderation/restrict.ts
+++ b/src/interactions/moderation/restrict.ts
@@ -1,174 +1,103 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const RestrictCommand = {
-	name: 'restrict',
-	description: 'Restrict a members access to write/tags/embed/react/emoji',
-	options: [
-		{
-			name: 'mute',
-			description: 'Mute a member of(f) this guild',
-			type: ApplicationCommandOptionType.Subcommand,
-			options: [
-				{
-					name: 'user',
-					description: 'The user to action',
-					type: ApplicationCommandOptionType.User,
-					required: true,
-				},
-				{
-					name: 'duration',
-					description: 'The duration',
-					type: ApplicationCommandOptionType.String,
-					choices: [
-						{ name: '3 hours', value: '3h' },
-						{ name: '6 hours', value: '6h' },
-						{ name: '12 hours', value: '12h' },
-						{ name: '1 day', value: '1d' },
-						{ name: '2 days', value: '2d' },
-						{ name: '3 days', value: '3d' },
-						{ name: '7 days', value: '7d' },
-					],
-					required: true,
-				},
-				{
-					name: 'reason',
-					description: 'The reason of this action',
-					type: ApplicationCommandOptionType.String,
-				},
-				{
-					name: 'reference',
-					description: 'The reference case',
-					type: ApplicationCommandOptionType.Integer,
-				},
-			],
-		},
-		{
-			name: 'embed',
-			description: 'Embed restrict a member of(f) this guild',
-			type: ApplicationCommandOptionType.Subcommand,
-			options: [
-				{
-					name: 'user',
-					description: 'The user to action',
-					type: ApplicationCommandOptionType.User,
-					required: true,
-				},
-				{
-					name: 'duration',
-					description: 'The duration',
-					type: ApplicationCommandOptionType.String,
-					choices: [
-						{ name: '3 hours', value: '3h' },
-						{ name: '6 hours', value: '6h' },
-						{ name: '12 hours', value: '12h' },
-						{ name: '1 day', value: '1d' },
-						{ name: '2 days', value: '2d' },
-						{ name: '3 days', value: '3d' },
-						{ name: '7 days', value: '7d' },
-					],
-					required: true,
-				},
-				{
-					name: 'reason',
-					description: 'The reason of this action',
-					type: ApplicationCommandOptionType.String,
-				},
-				{
-					name: 'reference',
-					description: 'The reference case',
-					type: ApplicationCommandOptionType.Integer,
-				},
-			],
-		},
-		{
-			name: 'react',
-			description: 'Reaction restrict a member of(f) this guild',
-			type: ApplicationCommandOptionType.Subcommand,
-			options: [
-				{
-					name: 'user',
-					description: 'The user to action',
-					type: ApplicationCommandOptionType.User,
-					required: true,
-				},
-				{
-					name: 'duration',
-					description: 'The duration',
-					type: ApplicationCommandOptionType.String,
-					choices: [
-						{ name: '3 hours', value: '3h' },
-						{ name: '6 hours', value: '6h' },
-						{ name: '12 hours', value: '12h' },
-						{ name: '1 day', value: '1d' },
-						{ name: '2 days', value: '2d' },
-						{ name: '3 days', value: '3d' },
-						{ name: '7 days', value: '7d' },
-					],
-					required: true,
-				},
-				{
-					name: 'reason',
-					description: 'The reason of this action',
-					type: ApplicationCommandOptionType.String,
-				},
-				{
-					name: 'reference',
-					description: 'The reference case',
-					type: ApplicationCommandOptionType.Integer,
-				},
-			],
-		},
-		{
-			name: 'emoji',
-			description: 'Emoji restrict a member of(f) this guild',
-			type: ApplicationCommandOptionType.Subcommand,
-			options: [
-				{
-					name: 'user',
-					description: 'The user to action',
-					type: ApplicationCommandOptionType.User,
-					required: true,
-				},
-				{
-					name: 'duration',
-					description: 'The duration',
-					type: ApplicationCommandOptionType.String,
-					choices: [
-						{ name: '3 hours', value: '3h' },
-						{ name: '6 hours', value: '6h' },
-						{ name: '12 hours', value: '12h' },
-						{ name: '1 day', value: '1d' },
-						{ name: '2 days', value: '2d' },
-						{ name: '3 days', value: '3d' },
-						{ name: '7 days', value: '7d' },
-					],
-					required: true,
-				},
-				{
-					name: 'reason',
-					description: 'The reason of this action',
-					type: ApplicationCommandOptionType.String,
-				},
-				{
-					name: 'reference',
-					description: 'The reference case',
-					type: ApplicationCommandOptionType.Integer,
-				},
-			],
-		},
-		{
-			name: 'unrole',
-			description: 'Unrole a specific case',
-			type: ApplicationCommandOptionType.Subcommand,
-			options: [
-				{
-					name: 'case',
-					description: 'The case to unrole',
-					type: ApplicationCommandOptionType.Integer,
-					required: true,
-				},
-			],
-		},
-	],
-	default_permission: false,
-} as const;
+export const RestrictCommand = new SlashCommandBuilder()
+	.setName('restrict')
+	.setDescription('Restrict a members access to write/tags/embed/react/emoji')
+	.addSubcommand((sub) =>
+		sub
+			.setName('mute')
+			.setDescription('Mute a member of(f) this guild')
+			.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+			.addStringOption((opt) =>
+				opt
+					.setName('duration')
+					.setDescription('The duration')
+					.setRequired(true)
+					.addChoices([
+						['3 hours', '3h'],
+						['6 hours', '6h'],
+						['12 hours', '12h'],
+						['1 day', '1d'],
+						['2 days', '2d'],
+						['3 days', '3d'],
+						['7 days', '7d'],
+					]),
+			)
+			.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+			.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false)),
+	)
+	.addSubcommand((sub) =>
+		sub
+			.setName('embed')
+			.setDescription('Embed restrict a member of(f) this guild')
+			.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+			.addStringOption((opt) =>
+				opt
+					.setName('duration')
+					.setDescription('The duration')
+					.setRequired(true)
+					.addChoices([
+						['3 hours', '3h'],
+						['6 hours', '6h'],
+						['12 hours', '12h'],
+						['1 day', '1d'],
+						['2 days', '2d'],
+						['3 days', '3d'],
+						['7 days', '7d'],
+					]),
+			)
+			.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+			.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false)),
+	)
+	.addSubcommand((sub) =>
+		sub
+			.setName('react')
+			.setDescription('Reaction restrict a member of(f) this guild')
+			.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+			.addStringOption((opt) =>
+				opt
+					.setName('duration')
+					.setDescription('The duration')
+					.setRequired(true)
+					.addChoices([
+						['3 hours', '3h'],
+						['6 hours', '6h'],
+						['12 hours', '12h'],
+						['1 day', '1d'],
+						['2 days', '2d'],
+						['3 days', '3d'],
+						['7 days', '7d'],
+					]),
+			)
+			.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+			.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false)),
+	)
+	.addSubcommand((sub) =>
+		sub
+			.setName('emoji')
+			.setDescription('Emoji restrict a member of(f) this guild')
+			.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+			.addStringOption((opt) =>
+				opt
+					.setName('duration')
+					.setDescription('The duration')
+					.setRequired(true)
+					.addChoices([
+						['3 hours', '3h'],
+						['6 hours', '6h'],
+						['12 hours', '12h'],
+						['1 day', '1d'],
+						['2 days', '2d'],
+						['3 days', '3d'],
+						['7 days', '7d'],
+					]),
+			)
+			.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+			.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false)),
+	)
+	.addSubcommand((sub) =>
+		sub
+			.setName('unrole')
+			.setDescription('Unrole a specific case')
+			.addIntegerOption((opt) => opt.setName('case').setDescription('The case to unrole').setRequired(true)),
+	);

--- a/src/interactions/moderation/softban.ts
+++ b/src/interactions/moderation/softban.ts
@@ -1,40 +1,24 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const SoftbanCommand = {
-	name: 'softban',
-	description: 'Softban a member of(f) this guild',
-	options: [
-		{
-			name: 'user',
-			description: 'The user to action',
-			type: ApplicationCommandOptionType.User,
-			required: true,
-		},
-		{
-			name: 'reason',
-			description: 'The reason of this action',
-			type: ApplicationCommandOptionType.String,
-		},
-		{
-			name: 'days',
-			description: 'The amount of days to deleted messages from',
-			type: ApplicationCommandOptionType.Integer,
-			choices: [
-				{ name: '0 days', value: 0 },
-				{ name: '1 day (default)', value: 1 },
-				{ name: '2 days', value: 2 },
-				{ name: '3 days', value: 3 },
-				{ name: '4 days', value: 4 },
-				{ name: '5 days', value: 5 },
-				{ name: '6 days', value: 6 },
-				{ name: '7 days', value: 7 },
-			],
-		},
-		{
-			name: 'reference',
-			description: 'The reference case',
-			type: ApplicationCommandOptionType.Integer,
-		},
-	],
-	default_permission: false,
-} as const;
+export const SoftbanCommand = new SlashCommandBuilder()
+	.setName('softban')
+	.setDescription('Softban a member of(f) this guild')
+	.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+	.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+	.addIntegerOption((opt) =>
+		opt
+			.setName('days')
+			.setDescription('The amount of days to deleted messages from')
+			.setRequired(false)
+			.addChoices([
+				['0 days', 0],
+				['1 day (default)', 1],
+				['2 days', 2],
+				['3 days', 3],
+				['4 days', 4],
+				['5 days', 5],
+				['6 days', 6],
+				['7 days', 7],
+			]),
+	)
+	.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false));

--- a/src/interactions/moderation/unban.ts
+++ b/src/interactions/moderation/unban.ts
@@ -1,25 +1,8 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const UnbanCommand = {
-	name: 'unban',
-	description: 'Unban a user',
-	options: [
-		{
-			name: 'user',
-			description: 'The user to action',
-			type: ApplicationCommandOptionType.User,
-			required: true,
-		},
-		{
-			name: 'reason',
-			description: 'The reason of this action',
-			type: ApplicationCommandOptionType.String,
-		},
-		{
-			name: 'reference',
-			description: 'The reference case',
-			type: ApplicationCommandOptionType.Integer,
-		},
-	],
-	default_permission: false,
-} as const;
+export const UnbanCommand = new SlashCommandBuilder()
+	.setName('unban')
+	.setDescription('Unban a user')
+	.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+	.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+	.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false));

--- a/src/interactions/moderation/warn.ts
+++ b/src/interactions/moderation/warn.ts
@@ -1,25 +1,8 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const WarnCommand = {
-	name: 'warn',
-	description: 'Warn a user',
-	options: [
-		{
-			name: 'user',
-			description: 'The user to action',
-			type: ApplicationCommandOptionType.User,
-			required: true,
-		},
-		{
-			name: 'reason',
-			description: 'The reason of this action',
-			type: ApplicationCommandOptionType.String,
-		},
-		{
-			name: 'reference',
-			description: 'The reference case',
-			type: ApplicationCommandOptionType.Integer,
-		},
-	],
-	default_permission: false,
-} as const;
+export const WarnCommand = new SlashCommandBuilder()
+	.setName('warn')
+	.setDescription('Warn a user')
+	.addUserOption((opt) => opt.setName('user').setDescription('The user to action').setRequired(true))
+	.addStringOption((opt) => opt.setName('reason').setDescription('The reason of this action').setRequired(false))
+	.addIntegerOption((opt) => opt.setName('reference').setDescription('The reference case').setRequired(false));

--- a/src/interactions/utility/ping.ts
+++ b/src/interactions/utility/ping.ts
@@ -1,13 +1,6 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { SlashCommandBuilder } from '@discordjs/builders';
 
-export const PingCommand = {
-	name: 'ping',
-	description: 'Health check',
-	options: [
-		{
-			name: 'hide',
-			description: 'Hides the output',
-			type: ApplicationCommandOptionType.Boolean,
-		},
-	],
-} as const;
+export const PingCommand = new SlashCommandBuilder()
+	.setName('ping')
+	.setDescription('Health check')
+	.addBooleanOption((opt) => opt.setName('hide').setDescription('Hides the output'));


### PR DESCRIPTION
This PR refactors all raw slash command objects to use the `@discordjs/builders` SlashCommandBuilder utility.

Blocked by https://github.com/discordjs/builders/pull/19.