### PR TITLE
feat(reason) allow optional range

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -30,7 +30,7 @@
 					"not_a_text_channel": "{{- channel}} is not a text channel.",
 					"no_case": "Cannot find case #{{case}}",
 					"no_case_range": "Invalid case range #{{lower_case}} to #{{upper_case}}",
-					"case_lower_one": "Case IDs have to be above 0",
+					"case_lower_one": "Case ids have to be above 0",
 					"no_ref_case": "Cannot find reference case #{{case}}"
 				}
 			},

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -30,6 +30,7 @@
 					"not_a_text_channel": "{{- channel}} is not a text channel.",
 					"no_case": "Cannot find case #{{case}}",
 					"no_case_range": "Invalid case range #{{lower_case}} to #{{upper_case}}",
+					"case_lower_one": "Case IDs have to be above 0",
 					"no_ref_case": "Cannot find reference case #{{case}}"
 				}
 			},

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -29,6 +29,7 @@
 					"max_length_reason": "Max length of 1900 for reason exceeded.",
 					"not_a_text_channel": "{{- channel}} is not a text channel.",
 					"no_case": "Cannot find case #{{case}}",
+					"no_case_range": "Invalid case range #{{lower_case}} to #{{upper_case}}",
 					"no_ref_case": "Cannot find reference case #{{case}}"
 				}
 			},
@@ -207,7 +208,14 @@
 				}
 			},
 			"reason": {
-				"success": "Successfully set reason for case {{- case}}"
+				"success": "Successfully set reason for case {{- case}}",
+				"success_multiple": "Successfully set reason for case range {{- lower_case}} to {{- upper_case}} ({{amount}}/{{target}} cases)",
+				"pending_multiple": "Do you really want to set a reason for case range {{- lower_case}} to {{- upper_case}} ({{amount}} cases)?",
+				"buttons": {
+					"cancel": "Cancel",
+					"execute": "Set Reason"
+				},
+				"cancel": "Cancelled setting reason"
 			},
 			"reference": {
 				"success": "Successfully set reference for case {{- case}} to {{- ref}}"

--- a/src/commands/moderation/reason.ts
+++ b/src/commands/moderation/reason.ts
@@ -115,6 +115,8 @@ export default class implements Command {
 					components: [],
 				});
 				return;
+			} else if (!collectedInteraction) {
+				return;
 			}
 		} else {
 			originalCaseLower = await getCase(interaction.guildId!, lower);

--- a/src/commands/moderation/reason.ts
+++ b/src/commands/moderation/reason.ts
@@ -1,4 +1,5 @@
 import { ButtonInteraction, CommandInteraction, Formatters, MessageActionRow, MessageButton } from 'discord.js';
+import { nanoid } from 'nanoid';
 import i18next from 'i18next';
 
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf';
@@ -11,7 +12,6 @@ import { checkLogChannel } from '../../functions/settings/checkLogChannel';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting';
 import { getCase } from '../../functions/cases/getCase';
 import { generateMessageLink } from '../../util/generateMessageLink';
-import { nanoid } from 'nanoid';
 import { logger } from '../../logger';
 import { truncate } from '../../util/embed';
 import type { Case } from '../../functions/cases/createCase';

--- a/src/commands/moderation/reason.ts
+++ b/src/commands/moderation/reason.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, Formatters } from 'discord.js';
+import { ButtonInteraction, CommandInteraction, Formatters, MessageActionRow, MessageButton } from 'discord.js';
 import i18next from 'i18next';
 
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf';
@@ -11,6 +11,10 @@ import { checkLogChannel } from '../../functions/settings/checkLogChannel';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting';
 import { getCase } from '../../functions/cases/getCase';
 import { generateMessageLink } from '../../util/generateMessageLink';
+import { nanoid } from 'nanoid';
+import { logger } from '../../logger';
+import { truncate } from '../../util/embed';
+import type { Case } from '../../functions/cases/createCase';
 
 export default class implements Command {
 	public async execute(
@@ -29,30 +33,146 @@ export default class implements Command {
 			throw new Error(i18next.t('common.errors.no_mod_log_channel', { lng: locale }));
 		}
 
-		const originalCase = await getCase(interaction.guildId!, args.case);
-		if (!originalCase) {
-			throw new Error(i18next.t('command.mod.common.errors.no_case', { case: args.case, lng: locale }));
-		}
-
 		if (args.reason.length >= 500) {
 			throw new Error(i18next.t('command.mod.common.errors.max_length_reason', { lng: locale }));
 		}
 
-		const case_ = await updateCase({
-			caseId: originalCase.caseId,
-			guildId: interaction.guildId!,
-			reason: args.reason,
-		});
-		await upsertCaseLog(interaction.guildId!, interaction.user, case_);
+		const lower = Math.min(args.case, args.lastcase ?? args.case);
+		const upper = Math.max(args.case, args.lastcase ?? args.case);
+
+		let originalCaseLower: Case | null;
+		let originalCaseUpper: Case | null;
+
+		if (args.lastcase) {
+			const changeKey = nanoid();
+			const cancelKey = nanoid();
+
+			const changeButton = new MessageButton()
+				.setCustomId(changeKey)
+				.setLabel(i18next.t('command.mod.reason.buttons.execute', { lng: locale }))
+				.setStyle('DANGER');
+			const cancelButton = new MessageButton()
+				.setCustomId(cancelKey)
+				.setLabel(i18next.t('command.mod.reason.buttons.cancel', { lng: locale }))
+				.setStyle('SECONDARY');
+
+			originalCaseLower = await getCase(interaction.guildId!, lower);
+			originalCaseUpper = await getCase(interaction.guildId!, upper);
+
+			if (!originalCaseLower || !originalCaseUpper) {
+				await interaction.editReply({
+					content: i18next.t('command.mod.common.errors.no_case_range', {
+						lower_case: lower,
+						upper_case: upper,
+						lng: locale,
+					}),
+					components: [],
+				});
+				return;
+			}
+
+			await interaction.editReply({
+				content: i18next.t('command.mod.reason.pending_multiple', {
+					lower_case: Formatters.hyperlink(
+						`#${lower}`,
+						generateMessageLink(interaction.guildId!, logChannel.id, originalCaseLower.logMessageId!),
+					),
+					upper_case: Formatters.hyperlink(
+						`#${upper}`,
+						generateMessageLink(interaction.guildId!, logChannel.id, originalCaseUpper.logMessageId!),
+					),
+					amount: upper - lower + 1,
+					lng: locale,
+				}),
+				components: [new MessageActionRow().addComponents([cancelButton, changeButton])],
+			});
+
+			const collectedInteraction = await interaction.channel
+				?.awaitMessageComponent<ButtonInteraction>({
+					filter: (collected) => collected.user.id === interaction.user.id,
+					componentType: 'BUTTON',
+					time: 15000,
+				})
+				.catch(async () => {
+					try {
+						await interaction.editReply({
+							content: i18next.t('common.errors.timed_out', { lng: locale }),
+							components: [],
+						});
+					} catch (e) {
+						logger.error(e, e.message);
+					}
+				});
+
+			if (
+				collectedInteraction &&
+				(collectedInteraction.customId === cancelKey || collectedInteraction.customId !== changeKey)
+			) {
+				await collectedInteraction.update({
+					content: i18next.t('command.mod.reason.cancel', {
+						lng: locale,
+					}),
+					components: [],
+				});
+				return;
+			}
+		} else {
+			originalCaseLower = await getCase(interaction.guildId!, lower);
+			if (!originalCaseLower) {
+				await interaction.editReply({
+					content: i18next.t('command.mod.common.errors.no_case', {
+						case: lower,
+						lng: locale,
+					}),
+					components: [],
+				});
+				return;
+			}
+		}
+
+		const success = [];
+
+		for (let caseId = lower; caseId <= upper; caseId++) {
+			const originalCase = await getCase(interaction.guildId!, caseId);
+			if (!originalCase) {
+				continue;
+			}
+
+			const case_ = await updateCase({
+				caseId: originalCase.caseId,
+				guildId: interaction.guildId!,
+				reason: args.reason,
+			});
+
+			await upsertCaseLog(interaction.guildId!, interaction.user, case_);
+			success.push(caseId);
+		}
+
+		const message = args.lastcase
+			? i18next.t('command.mod.reason.success_multiple', {
+					lower_case: Formatters.hyperlink(
+						`#${lower}`,
+						generateMessageLink(interaction.guildId!, logChannel.id, originalCaseLower.logMessageId!),
+					),
+					upper_case: Formatters.hyperlink(
+						`#${upper}`,
+						generateMessageLink(interaction.guildId!, logChannel.id, originalCaseUpper!.logMessageId!),
+					),
+					amount: success.length,
+					target: upper - lower + 1,
+					lng: locale,
+			  })
+			: i18next.t('command.mod.reason.success', {
+					case: Formatters.hyperlink(
+						`#${lower}`,
+						generateMessageLink(interaction.guildId!, logChannel.id, originalCaseLower.logMessageId!),
+					),
+					lng: locale,
+			  });
 
 		await interaction.editReply({
-			content: i18next.t('command.mod.reason.success', {
-				case: Formatters.hyperlink(
-					`#${originalCase.caseId}`,
-					generateMessageLink(interaction.guildId!, logChannel.id, originalCase.logMessageId!),
-				),
-				lng: locale,
-			}),
+			content: truncate(message, 1000, ''),
+			components: [],
 		});
 	}
 }

--- a/src/commands/moderation/reason.ts
+++ b/src/commands/moderation/reason.ts
@@ -40,6 +40,16 @@ export default class implements Command {
 		const lower = Math.min(args.case, args.lastcase ?? args.case);
 		const upper = Math.max(args.case, args.lastcase ?? args.case);
 
+		if (lower < 1 || upper < 1) {
+			await interaction.editReply({
+				content: i18next.t('command.mod.common.errors.case_lower_one', {
+					lng: locale,
+				}),
+				components: [],
+			});
+			return;
+		}
+
 		let originalCaseLower: Case | null;
 		let originalCaseUpper: Case | null;
 

--- a/src/commands/moderation/reason.ts
+++ b/src/commands/moderation/reason.ts
@@ -45,7 +45,6 @@ export default class implements Command {
 				content: i18next.t('command.mod.common.errors.case_lower_one', {
 					lng: locale,
 				}),
-				components: [],
 			});
 			return;
 		}

--- a/src/interactions/moderation/reason.ts
+++ b/src/interactions/moderation/reason.ts
@@ -20,7 +20,6 @@ export const ReasonCommand = {
 			name: 'lastcase',
 			description: 'The last case to change',
 			type: ApplicationCommandOptionType.Integer,
-			required: false,
 		},
 	],
 	default_permission: false,

--- a/src/interactions/moderation/reason.ts
+++ b/src/interactions/moderation/reason.ts
@@ -2,11 +2,11 @@ import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 
 export const ReasonCommand = {
 	name: 'reason',
-	description: 'Change the reason of an action',
+	description: 'Change the reason of actions',
 	options: [
 		{
 			name: 'case',
-			description: 'The case to look up',
+			description: 'The first case to change',
 			type: ApplicationCommandOptionType.Integer,
 			required: true,
 		},
@@ -15,6 +15,12 @@ export const ReasonCommand = {
 			description: 'The reason',
 			type: ApplicationCommandOptionType.String,
 			required: true,
+		},
+		{
+			name: 'lastcase',
+			description: 'The last case to change',
+			type: ApplicationCommandOptionType.Integer,
+			required: false,
 		},
 	],
 	default_permission: false,

--- a/src/util/embed.ts
+++ b/src/util/embed.ts
@@ -57,3 +57,18 @@ export function truncateEmbed(embed: APIEmbed): APIEmbed {
 			: [],
 	};
 }
+
+export function truncate(text: string, len: number, splitChar = ' '): string {
+	if (text.length <= len) return text;
+	const words = text.split(splitChar);
+	const res: string[] = [];
+	for (const word of words) {
+		const full = res.join(splitChar);
+		if (full.length + word.length + 1 <= len - 3) {
+			res.push(word);
+		}
+	}
+
+	const resText = res.join(splitChar);
+	return resText.length === text.length ? resText : `${resText.trim()}...`;
+}


### PR DESCRIPTION
* Allow reason slash command to (optionally) take a "last case" option for bulk setting case reasons
* Reject if first or last case is invalid
* Require confirmation flow in case of range (no confirmation for single case)
* Supply information about the amount of failed attempts in success message in case of range

---

* `truncate` utility (contrary to ellipsis this takes split characters into consideration and only adds chunks up to the next split character to the result. this is preferable here to not apply an ellipsis mid-link formatting and break escapes)

---

| ℹ️  Due to the nature of slash command argument order the optional last case has to sit behind the reason, causing somewhat unintuitive command usage. This could be prevented by splitting the command into sub-commands, however, I decided against this approach to not unnecessarily clutter the command list. |
| --- |

--- 
<details>
<summary>Failcase</summary>

![image](https://user-images.githubusercontent.com/26532370/131586849-b9fd6c8f-d2f0-4be2-9c49-cd4702574921.png)

</details>
<details>
<summary>Confirmation required</summary>

![image](https://user-images.githubusercontent.com/26532370/131587022-ddb8b7c8-f192-49a9-99b2-a3cba5d53d84.png)

</details>
<details>
<summary>Success</summary>

![image](https://user-images.githubusercontent.com/26532370/131586978-7de40afc-6ef5-4b03-a91b-2b3cca9ed2c6.png)

</details>
