### PR TITLE
fix(unban): respect reason on manual unban

### DIFF
--- a/src/events/manual-ban/guildBanRemove.ts
+++ b/src/events/manual-ban/guildBanRemove.ts
@@ -76,6 +76,7 @@ export default class implements Event {
 					target: guildBan.user,
 					manual: true,
 					skipAction: true,
+					reason: logs?.reason,
 				});
 				await upsertCaseLog(guildBan.guild.id, logs?.executor, case_);
 			} catch (e) {

--- a/src/functions/cases/deleteCase.ts
+++ b/src/functions/cases/deleteCase.ts
@@ -13,7 +13,7 @@ interface DeleteCaseOptions {
 	messageId?: Snowflake;
 	target?: User;
 	caseId?: number;
-	reason?: string;
+	reason?: string | null;
 	manual?: boolean;
 	skipAction?: boolean;
 }


### PR DESCRIPTION
While an unban reason cannot be provided in the GUI, other bots might be able to. Currently, the reason retrieved from the audit log (if present) is ignored. 

![image](https://user-images.githubusercontent.com/26532370/131589535-4c798ae6-f8a4-42ab-a489-1ff5ff1a4122.png)

This PR fixes this by passing the audit log reason to `deleteCase`.