### PR TITLE
fix(nuke): member count in log embed

### DIFF
--- a/src/commands/moderation/anti-raid-nuke.ts
+++ b/src/commands/moderation/anti-raid-nuke.ts
@@ -191,7 +191,7 @@ export default class implements Command {
 				collectedInteraction.user,
 				logChannel,
 				cases,
-				args.reason ?? i18next.t('command.mod.anti_raid_nuke.success', { lng: locale }),
+				args.reason ?? i18next.t('command.mod.anti_raid_nuke.success', { lng: locale, members: fatalities.length }),
 			);
 
 			const membersHit = Buffer.from(fatalities.map((member) => member.user.id).join('\r\n'));


### PR DESCRIPTION
Anti-Raid-Nuke currently falls back to `Anti-Raid-Nuke hit {{- members}} guild members.` as a reason in the log embed, if no reason is supplied to the command. This PR adds the count of fatalities as the `members` parameter to properly display hit count, as expected.

current behavior with missing fatality count:
![image](https://user-images.githubusercontent.com/26532370/132104078-d4a7e3b2-9cd5-4f6a-ba54-202d42dc19d3.png)
