### PR TITLE
feat: log attachment proxy on single msg delete

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -286,6 +286,7 @@
 				"info": "\u200b",
 				"channel": "• Channel: {{- channel}}",
 				"embeds": "• Embeds: {{- embeds}}",
+				"attachments": "• Attachments: {{- attachments}}",
 				"jump_to": "• [Jump to]({{- link}})"
 			},
 			"message_bulk_deleted": {

--- a/src/events/guild-log/messageDelete.ts
+++ b/src/events/guild-log/messageDelete.ts
@@ -28,7 +28,7 @@ export default class implements Event {
 			if (!message.guild) {
 				continue;
 			}
-			if (!message.content && !message.embeds.length) {
+			if (!message.content && !message.embeds.length && !message.attachments.size) {
 				continue;
 			}
 
@@ -65,7 +65,11 @@ export default class implements Event {
 					color: 12016895,
 					title: i18next.t('log.guild_log.message_deleted.title'),
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-					description: `${message.content ?? i18next.t('log.guild_log.message_deleted.no_content', { lng: locale })}`,
+					description: `${
+						message.content.length
+							? message.content
+							: i18next.t('log.guild_log.message_deleted.no_content', { lng: locale })
+					}`,
 					timestamp: new Date().toISOString(),
 				});
 
@@ -75,6 +79,20 @@ export default class implements Event {
 						lng: locale,
 					})}`;
 				}
+
+				if (message.attachments.size) {
+					const attachmentParts = [];
+					let counter = 1;
+					for (const attachment of message.attachments.values()) {
+						attachmentParts.push(`[${counter}](${attachment.proxyURL})`);
+						counter++;
+					}
+					info += `\n${i18next.t('log.guild_log.message_deleted.attachments', {
+						attachments: attachmentParts.join(' '),
+						lng: locale,
+					})}`;
+				}
+
 				info += `\n${i18next.t('log.guild_log.message_deleted.jump_to', { link: message.url, lng: locale })}`;
 
 				embed = addFields(embed, {

--- a/src/events/guild-log/messageDeleteBulk.ts
+++ b/src/events/guild-log/messageDeleteBulk.ts
@@ -59,7 +59,7 @@ export default class implements Event {
 						msg.author.id
 					}): ${msg.cleanContent ? msg.cleanContent.replace(/\n/g, '\r\n') : ''}${
 						attachments.size
-							? `\r\n${attachments.map((attachment) => `❯ Attachment: ${attachment.proxyURL}`).join('\r\n')}`
+							? `\r\n${attachments.map((attachment) => `↳ Attachment: ${attachment.proxyURL}`).join('\r\n')}`
 							: ''
 					}\r\n`;
 					return out;


### PR DESCRIPTION
- Fix contentless messages not getting the "No content" description (content is empty string, not nullish)
- Change the bulk delete symbol to an arrow to more clearly associate attachments with the message they belong to
- Add attachment logs to single message delete guild logs (useful to access deleted files shortly after deletion for moderation purposes) (deliberate decision against re-uploading the file to prevent accidental redistribution of content)

![image](https://user-images.githubusercontent.com/26532370/133760071-3aa60c8b-0872-4340-b319-e03a1fb9d676.png)
![image](https://user-images.githubusercontent.com/26532370/133760332-27a64374-8a9a-45b3-9b9c-b5691ae17845.png)

