### PR TITLE
fix(lockdown): permissions

### DIFF
--- a/src/commands/moderation/lockdown.ts
+++ b/src/commands/moderation/lockdown.ts
@@ -19,10 +19,6 @@ export default class implements Command {
 		await interaction.deferReply({ ephemeral: true });
 		await checkModRole(interaction, locale);
 
-		const {
-			client: { user: clientUser },
-		} = interaction;
-
 		switch (Object.keys(args)[0]) {
 			case 'lock': {
 				if (args.lock.channel && !args.lock.channel.isText()) {
@@ -40,7 +36,7 @@ export default class implements Command {
 				}
 
 				const targetChannel = (args.lock.channel ?? interaction.channel) as TextChannel;
-				const targetChannelClientPermissions = targetChannel.permissionsFor(clientUser!);
+				const targetChannelClientPermissions = targetChannel.permissionsFor(interaction.client.user!);
 
 				if (
 					!targetChannelClientPermissions?.has([PermissionFlagsBits.ManageRoles | PermissionFlagsBits.ManageChannels])

--- a/src/commands/moderation/sub/lockdown/lift.ts
+++ b/src/commands/moderation/sub/lockdown/lift.ts
@@ -9,7 +9,7 @@ export async function lift(interaction: CommandInteraction, channel: TextChannel
 	const lockdown = await getLockdown(interaction.guildId!, channel.id);
 	if (!lockdown) {
 		throw new Error(
-			i18next.t('command.mod.lockdown.lock.not_locked', {
+			i18next.t('command.mod.lockdown.lock.errors.not_locked', {
 				// eslint-disable-next-line @typescript-eslint/no-base-to-string
 				channel: `${channel.toString()} - ${channel.name} (${channel.id})`,
 				lng: locale,

--- a/src/commands/moderation/sub/lockdown/lock.ts
+++ b/src/commands/moderation/sub/lockdown/lock.ts
@@ -22,7 +22,7 @@ export async function lock(
 	const lockdown = await getLockdown(interaction.guildId!, args.channel.id);
 	if (lockdown) {
 		throw new Error(
-			i18next.t('command.mod.lockdown.lock.already_locked', {
+			i18next.t('command.mod.lockdown.lock.errors.already_locked', {
 				// eslint-disable-next-line @typescript-eslint/no-base-to-string
 				channel: `${args.channel.toString()} - ${args.channel.name} (${args.channel.id})`,
 				lng: locale,

--- a/src/functions/lockdowns/createLockdown.ts
+++ b/src/functions/lockdowns/createLockdown.ts
@@ -29,9 +29,6 @@ export async function createLockdown(lockdown: CreateLockdown & { channel: Guild
 	const sql = container.resolve<Sql<any>>(kSQL);
 
 	const overwrites = [...lockdown.channel.permissionOverwrites.cache.values()];
-	const {
-		client: { user: clientUser },
-	} = lockdown.channel;
 
 	await lockdown.channel.permissionOverwrites.set([
 		{
@@ -46,7 +43,7 @@ export async function createLockdown(lockdown: CreateLockdown & { channel: Guild
 			type: 'role',
 		},
 		{
-			id: clientUser!.id,
+			id: lockdown.channel.client.user!.id,
 			allow: PermissionFlagsBits.SendMessages | PermissionFlagsBits.ManageChannels | PermissionFlagsBits.ManageRoles,
 			type: 'member',
 		},

--- a/src/interactions/moderation/lockdown.ts
+++ b/src/interactions/moderation/lockdown.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { ApplicationCommandOptionType, ChannelType } from 'discord-api-types/v9';
 
 export const LockdownCommand = {
 	name: 'lockdown',
@@ -28,6 +28,7 @@ export const LockdownCommand = {
 					name: 'channel',
 					description: 'The channel to lock',
 					type: ApplicationCommandOptionType.Channel,
+					channel_types: ChannelType.GuildText,
 				},
 				{
 					name: 'reason',
@@ -45,6 +46,7 @@ export const LockdownCommand = {
 					name: 'channel',
 					description: 'The channel to lift the lock',
 					type: ApplicationCommandOptionType.Channel,
+					channel_types: ChannelType.GuildText,
 				},
 			],
 		},


### PR DESCRIPTION
- fix i18n strings to correctly specify `.errors` in the path
- return early if the permissions to create overwrites are missing
- deny permissions regarding threads on lockdown
- add overwrite so the bot is able to send lockdown messages without administrator permissions
- QoL: narrow text channel type allowed for lockdown command to `GUILD_TEXT`