### PR TITLE
feat(scams): use scam counter disconnected from spam checks

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -6,10 +6,11 @@ export const enum JobType {
 
 export const MAX_TRUST_ACCOUNT_AGE = 1000 * 60 * 60 * 24 * 7 * 4;
 export const SPAM_THRESHOLD = 5;
-export const SPAM_SCAM_THRESHOLD = 3;
 export const SPAM_EXPIRE_SECONDS = 20;
 export const MENTION_THRESHOLD = 10;
 export const MENTION_EXPIRE_SECONDS = 20;
+export const SCAM_THRESHOLD = 3;
+export const SCAM_EXPIRE_SECONDS = 20;
 
 export const DATE_FORMAT_LOGFILE = 'YYYY-MM-DD_HH-mm-ss';
 

--- a/src/events/anti-scam/messageCreate.ts
+++ b/src/events/anti-scam/messageCreate.ts
@@ -1,0 +1,81 @@
+import { Client, Constants, Message } from 'discord.js';
+import { inject, injectable } from 'tsyringe';
+import { on } from 'node:events';
+import type { Redis } from 'ioredis';
+import i18next from 'i18next';
+
+import type { Event } from '../../Event';
+import { logger } from '../../logger';
+import { Case, CaseAction, createCase } from '../../functions/cases/createCase';
+import { upsertCaseLog } from '../../functions/logs/upsertCaseLog';
+import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting';
+import { SCAM_THRESHOLD } from '../../Constants';
+import { checkLogChannel } from '../../functions/settings/checkLogChannel';
+import { kRedis } from '../../tokens';
+import { totalScams } from '../../functions/anti-scam/totalScam';
+
+@injectable()
+export default class implements Event {
+	public name = 'Spam check';
+
+	public event = Constants.Events.MESSAGE_CREATE;
+
+	public constructor(public readonly client: Client<true>, @inject(kRedis) public readonly redis: Redis) {}
+
+	public async execute(): Promise<void> {
+		for await (const [message] of on(this.client, this.event) as AsyncIterableIterator<[Message]>) {
+			try {
+				if (message.author.bot || !message.guild || !message.guildId || !message.content.length) continue;
+
+				const totalScamCount = await totalScams(message.content, message.guildId, message.author.id);
+				const scamExceeded = totalScamCount >= SCAM_THRESHOLD;
+
+				if (scamExceeded) {
+					if (!message.member?.bannable) continue;
+
+					const logChannel = await checkLogChannel(
+						message.guild,
+						await getGuildSetting(message.guildId, SettingsKeys.ModLogChannelId),
+					);
+					if (!logChannel) {
+						continue;
+					}
+
+					const locale = await getGuildSetting(message.guildId, SettingsKeys.Locale);
+
+					await this.redis.setex(`guild:${message.guildId}:user:${message.author.id}:ban`, 15, '');
+					let case_: Case | null = null;
+
+					logger.info(
+						{
+							event: { name: this.name, event: this.event },
+							guildId: message.guild.id,
+							userId: message.client.user!.id,
+							memberId: message.author.id,
+							scamExceeded,
+						},
+						`Member ${message.author.id} banned (scam)`,
+					);
+
+					case_ = await createCase(message.guild, {
+						targetId: message.author.id,
+						guildId: message.guildId,
+						action: CaseAction.Ban,
+						targetTag: message.author.tag,
+						reason: i18next.t('log.mod_log.scam.reason', {
+							lng: locale,
+						}),
+						deleteMessageDays: 1,
+					});
+
+					await upsertCaseLog(message.guildId, this.client.user, case_);
+				}
+			} catch (e) {
+				const error = e as Error;
+				logger.error(error, error.message);
+			}
+
+			continue;
+		}
+	}
+}

--- a/src/events/anti-spam/messageCreate.ts
+++ b/src/events/anti-spam/messageCreate.ts
@@ -9,12 +9,12 @@ import { logger } from '../../logger';
 import { Case, CaseAction, createCase } from '../../functions/cases/createCase';
 import { upsertCaseLog } from '../../functions/logs/upsertCaseLog';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting';
-import { MENTION_THRESHOLD, SPAM_SCAM_THRESHOLD, SPAM_THRESHOLD } from '../../Constants';
+import { MENTION_THRESHOLD, SCAM_THRESHOLD, SPAM_THRESHOLD } from '../../Constants';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel';
 import { totalMentions } from '../../functions/anti-spam/totalMentions';
 import { totalContent } from '../../functions/anti-spam/totalContents';
-import { checkScam } from '../../functions/anti-scam/checkScam';
 import { kRedis } from '../../tokens';
+import { totalScams } from '../../functions/anti-scam/totalScam';
 
 @injectable()
 export default class implements Event {
@@ -27,34 +27,33 @@ export default class implements Event {
 	public async execute(): Promise<void> {
 		for await (const [message] of on(this.client, this.event) as AsyncIterableIterator<[Message]>) {
 			try {
-				if (message.author.bot || !message.guild || !message.content.length) continue;
+				if (message.author.bot || !message.guild || !message.guildId || !message.content.length) continue;
 
 				const totalMentionCount = await totalMentions(message);
-				const totalContentCount = await totalContent(message.content, message.guild.id, message.author.id);
+				const totalContentCount = await totalContent(message.content, message.guildId, message.author.id);
+				const totalScamCount = await totalScams(message.content, message.guildId, message.author.id);
 
 				const mentionExceeded = totalMentionCount >= MENTION_THRESHOLD;
 				const contentExceeded = totalContentCount >= SPAM_THRESHOLD;
-				const scamContentExceeded = totalContentCount >= SPAM_SCAM_THRESHOLD;
+				const scamExceeded = totalScamCount >= SCAM_THRESHOLD;
 
-				const scamDomains = await checkScam(message.content);
-
-				if ((scamContentExceeded && scamDomains.length) || mentionExceeded || contentExceeded) {
+				if (scamExceeded || mentionExceeded || contentExceeded) {
 					if (!message.member?.bannable) continue;
 
 					const logChannel = await checkLogChannel(
 						message.guild,
-						await getGuildSetting(message.guild.id, SettingsKeys.ModLogChannelId),
+						await getGuildSetting(message.guildId, SettingsKeys.ModLogChannelId),
 					);
 					if (!logChannel) {
 						continue;
 					}
 
-					const locale = await getGuildSetting(message.guild.id, SettingsKeys.Locale);
+					const locale = await getGuildSetting(message.guildId, SettingsKeys.Locale);
 
-					await this.redis.setex(`guild:${message.guild.id}:user:${message.author.id}:ban`, 15, '');
+					await this.redis.setex(`guild:${message.guildId}:user:${message.author.id}:ban`, 15, '');
 					let case_: Case | null = null;
 
-					if ((scamContentExceeded && scamDomains.length) || mentionExceeded) {
+					if (scamExceeded || mentionExceeded) {
 						logger.info(
 							{
 								event: { name: this.name, event: this.event },
@@ -62,17 +61,17 @@ export default class implements Event {
 								userId: message.client.user!.id,
 								memberId: message.author.id,
 								mentionExceeded,
-								scamDomains,
+								scamExceeded,
 							},
 							`Member ${message.author.id} banned (spam/scam)`,
 						);
 
 						case_ = await createCase(message.guild, {
 							targetId: message.author.id,
-							guildId: message.guild.id,
+							guildId: message.guildId,
 							action: CaseAction.Ban,
 							targetTag: message.author.tag,
-							reason: i18next.t(scamDomains.length ? 'log.mod_log.scam.reason' : 'log.mod_log.spam.reason_mentions', {
+							reason: i18next.t(scamExceeded ? 'log.mod_log.scam.reason' : 'log.mod_log.spam.reason_mentions', {
 								lng: locale,
 							}),
 							deleteMessageDays: 1,
@@ -81,14 +80,14 @@ export default class implements Event {
 						logger.info(
 							{
 								event: { name: this.name, event: this.event },
-								guildId: message.guild.id,
+								guildId: message.guildId,
 								userId: message.client.user!.id,
 								memberId: message.author.id,
 							},
 							`Member ${message.author.id} softbanned (spam)`,
 						);
 
-						await this.redis.setex(`guild:${message.guild.id}:user:${message.author.id}:unban`, 15, '');
+						await this.redis.setex(`guild:${message.guildId}:user:${message.author.id}:unban`, 15, '');
 						case_ = await createCase(message.guild, {
 							targetId: message.author.id,
 							guildId: message.guild.id,
@@ -99,7 +98,7 @@ export default class implements Event {
 						});
 					}
 
-					await upsertCaseLog(message.guild.id, this.client.user, case_!);
+					await upsertCaseLog(message.guildId, this.client.user, case_!);
 				}
 			} catch (e) {
 				const error = e as Error;

--- a/src/functions/anti-scam/checkScam.ts
+++ b/src/functions/anti-scam/checkScam.ts
@@ -16,7 +16,8 @@ export async function checkScam(content: string): Promise<string[]> {
 	let matches: any[] | null = [];
 	while ((matches = urlRegex.exec(content)) !== null) {
 		const url = matches[0];
-		const hit = scamDomains.find((d) => url.toLowerCase().includes(d));
+		const urlLower = url.toLowerCase();
+		const hit = scamDomains.find((d) => urlLower.includes(d.toLowerCase()));
 
 		if (hit) {
 			trippedDomains.push(hit);
@@ -25,7 +26,8 @@ export async function checkScam(content: string): Promise<string[]> {
 
 		try {
 			const resolved = await resolveRedirect(url);
-			const hit = scamDomains.find((domain) => resolved.toLowerCase().includes(domain));
+			const resolvedLower = resolved.toLowerCase();
+			const hit = scamDomains.find((domain) => resolvedLower.includes(domain));
 			if (hit) {
 				trippedDomains.push(hit);
 			}

--- a/src/functions/anti-scam/totalScam.ts
+++ b/src/functions/anti-scam/totalScam.ts
@@ -1,0 +1,17 @@
+import type { Redis } from 'ioredis';
+import { container } from 'tsyringe';
+import { SCAM_EXPIRE_SECONDS } from '../../Constants';
+
+import { kRedis } from '../../tokens';
+import { checkScam } from './checkScam';
+
+export async function totalScams(content: string, guildId: string, userId: string): Promise<number> {
+	const redis = container.resolve<Redis>(kRedis);
+
+	const scamKey = `guild:${guildId}:user:${userId}:scams`;
+	const hitDomains = await checkScam(content);
+
+	const total = redis.incrby(scamKey, hitDomains.length ? 1 : 0);
+	await redis.expire(scamKey, SCAM_EXPIRE_SECONDS);
+	return total;
+}


### PR DESCRIPTION
- Disconnect scam checks from spam counter
- Use scam counter with reset timer to check for scams
- Optimize lowercasing of comparison string
- One unique increase per message, no matter how many scam domains (scenario: user listing scam domains to report, gets banned because the threshold is exceeded)