### PR TITLE
feat(antiscam): debug commands

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -237,6 +237,12 @@
 		"utility": {
 			"ping": {
 				"success": "ok"
+			},
+			"check_scam": {
+				"found_plural": "Detected domains ({{count}})",
+				"cache": "Checked against {{count}} scam domains",
+				"found": "Detected domains ({{count}})"
+			},
 			}
 		}
 	},

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -239,10 +239,20 @@
 				"success": "ok"
 			},
 			"check_scam": {
-				"found_plural": "Detected domains ({{count}})",
-				"cache": "Checked against {{count}} scam domains",
-				"found": "Detected domains ({{count}})"
+				"found": "Detected scam domain ({{count}})",
+				"found_plural": "Detected scam domains ({{count}})",
+				"debug": {
+					"title": "Debug information",
+					"domains": "• Domains: `{{count}}`",
+					"last_update": "• Last update: {{- refresh}}",
+					"refresh_never": "`never`"
+				}
 			},
+			"refresh_scamlist": {
+				"missing_env": "Missing environment variable to fetch scam domains from.",
+				"success": "Success! Refreshed scam domains. before: `{{before}}` after: `{{after}}` last update: {{- refresh}}",
+				"success_replace": "Success! Replaced scam domains (deleted old before fetching). before: `{{before}}` after: `{{after}}` last update: {{- refresh}}",
+				"refresh_never": "`never`"
 			}
 		}
 	},

--- a/src/commands/utility/checkScam.ts
+++ b/src/commands/utility/checkScam.ts
@@ -19,14 +19,24 @@ export default class implements Command {
 		const redis = container.resolve<Redis>(kRedis);
 		const domains = await checkScam(args.content);
 		const cardinality = await redis.scard('scamdomains');
+		const lastRefresh = await redis.get('scamdomains:refresh');
+
+		const debugParts = [
+			i18next.t('command.utility.check_scam.debug.domains', { lng: locale, count: cardinality }),
+			i18next.t('command.utility.check_scam.debug.last_update', {
+				lng: locale,
+				refresh: lastRefresh
+					? `<t:${Math.floor(parseInt(lastRefresh, 10) / 1000)}:f> (<t:${Math.floor(
+							parseInt(lastRefresh, 10) / 1000,
+					  )}:R>)`
+					: i18next.t('command.utility.check_scam.debug.refresh_never', { lng: locale }),
+			}),
+		];
 
 		const embed = new MessageEmbed()
 			.setColor(domains.length ? 16462404 : 3908957)
 			.setDescription(args.content)
-			.setFooter(
-				i18next.t('command.utility.check_scam.cache', { lng: locale, count: cardinality }),
-				interaction.client.user?.displayAvatarURL(),
-			);
+			.addField(i18next.t('command.utility.check_scam.debug.title', { lng: locale }), debugParts.join('\n'));
 
 		if (domains.length) {
 			embed.addField(

--- a/src/commands/utility/checkScam.ts
+++ b/src/commands/utility/checkScam.ts
@@ -1,0 +1,42 @@
+import { BaseCommandInteraction, MessageEmbed } from 'discord.js';
+import i18next from 'i18next';
+import type { Redis } from 'ioredis';
+import { container } from 'tsyringe';
+
+import type { ArgumentsOf } from '../../interactions/ArgumentsOf';
+import type { Command } from '../../Command';
+import type { CheckScamCommand } from '../../interactions';
+import { kRedis } from '../../tokens';
+import { checkScam } from '../../functions/anti-scam/checkScam';
+import { truncateEmbed } from '../../util/embed';
+
+export default class implements Command {
+	public async execute(
+		interaction: BaseCommandInteraction,
+		args: ArgumentsOf<typeof CheckScamCommand>,
+		locale: string,
+	): Promise<void> {
+		const redis = container.resolve<Redis>(kRedis);
+		const domains = await checkScam(args.content);
+		const cardinality = await redis.scard('scamdomains');
+
+		const embed = new MessageEmbed()
+			.setColor(domains.length ? 16462404 : 3908957)
+			.setDescription(args.content)
+			.setFooter(
+				i18next.t('command.utility.check_scam.cache', { lng: locale, count: cardinality }),
+				interaction.client.user?.displayAvatarURL(),
+			);
+
+		if (domains.length) {
+			embed.addField(
+				i18next.t('command.utility.check_scam.found', { lng: locale, count: domains.length }),
+				domains.map((domain) => `• \`${domain}\``).join('\n'),
+			);
+		}
+
+		await interaction.deferReply({ ephemeral: args.hide ?? true });
+
+		await interaction.editReply({ embeds: [truncateEmbed(embed.toJSON())] });
+	}
+}

--- a/src/commands/utility/refreshscams.ts
+++ b/src/commands/utility/refreshscams.ts
@@ -1,0 +1,76 @@
+import type { BaseCommandInteraction } from 'discord.js';
+import i18next from 'i18next';
+import type { Redis } from 'ioredis';
+import { container } from 'tsyringe';
+
+import type { ArgumentsOf } from '../../interactions/ArgumentsOf';
+import type { Command } from '../../Command';
+import type { RefreshScamlistCommand } from '../../interactions';
+import fetch, { Response } from 'node-fetch';
+
+import { kRedis } from '../../tokens';
+import { logger } from '../../logger';
+
+export function checkResponse(response: Response) {
+	if (response.ok) return response;
+	logger.warn({ response }, 'Fetching scam domains returned a non 2xx response code.');
+	return response;
+}
+
+export default class implements Command {
+	public async execute(
+		interaction: BaseCommandInteraction,
+		args: ArgumentsOf<typeof RefreshScamlistCommand>,
+		locale: string,
+	): Promise<void> {
+		const redis = container.resolve<Redis>(kRedis);
+		await interaction.deferReply({ ephemeral: true });
+
+		if (!process.env.SCAM_DOMAIN_URL) {
+			logger.warn('Missing environment variable: SCAM_DOMAIN_URL.');
+			await interaction.editReply(i18next.t('command.utility.refresh_scamlist.missing_env', { lng: locale }));
+			return;
+		}
+
+		const list = await fetch(process.env.SCAM_DOMAIN_URL)
+			.then(checkResponse)
+			.then((r) => r.json());
+
+		const lastRefresh = await redis.get('scamdomains:refresh');
+		const before = await redis.scard('scamdomains');
+
+		if (args.replace) {
+			await redis.del('scamdomains');
+		}
+
+		await redis.sadd('scamdomains', ...list);
+		const after = await redis.scard('scamdomains');
+
+		logger.info(
+			{
+				before,
+				after,
+				replaced: args.replace ?? false,
+				manual: true,
+			},
+			'Scam domains updated',
+		);
+		await redis.set('scamdomains:refresh', Date.now());
+
+		await interaction.editReply(
+			i18next.t(
+				args.replace ? 'command.utility.refresh_scamlist.success_replace' : 'command.utility.refresh_scamlist.success',
+				{
+					lng: locale,
+					before,
+					after,
+					refresh: lastRefresh
+						? `<t:${Math.floor(parseInt(lastRefresh, 10) / 1000)}:f> (<t:${Math.floor(
+								parseInt(lastRefresh, 10) / 1000,
+						  )}:R>)`
+						: i18next.t('command.utility.refresh_scamlist.refresh_never', { lng: locale }),
+				},
+			),
+		);
+	}
+}

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -23,6 +23,7 @@ import {
 
 	// Utility
 	PingCommand,
+	CheckScamCommand,
 
 	// Context Menu
 	HistoryContextMenuCommand,
@@ -56,6 +57,7 @@ try {
 
 				// Utility
 				PingCommand,
+				CheckScamCommand,
 
 				// Context Menu
 				HistoryContextMenuCommand,

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -24,6 +24,7 @@ import {
 	// Utility
 	PingCommand,
 	CheckScamCommand,
+	RefreshScamlistCommand,
 
 	// Context Menu
 	HistoryContextMenuCommand,
@@ -58,6 +59,7 @@ try {
 				// Utility
 				PingCommand,
 				CheckScamCommand,
+				RefreshScamlistCommand,
 
 				// Context Menu
 				HistoryContextMenuCommand,

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -12,5 +12,6 @@ export * from './moderation/unban';
 export * from './moderation/warn';
 export * from './utility/ping';
 export * from './utility/checkScam';
+export * from './utility/refreshscams';
 
 export * from './context-menu/history';

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -11,5 +11,6 @@ export * from './moderation/softban';
 export * from './moderation/unban';
 export * from './moderation/warn';
 export * from './utility/ping';
+export * from './utility/checkScam';
 
 export * from './context-menu/history';

--- a/src/interactions/utility/checkScam.ts
+++ b/src/interactions/utility/checkScam.ts
@@ -1,0 +1,19 @@
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+
+export const CheckScamCommand = {
+	name: 'checkscam',
+	description: 'Check provided content for scam domains',
+	options: [
+		{
+			name: 'content',
+			description: 'String to check',
+			type: ApplicationCommandOptionType.String,
+			required: true,
+		},
+		{
+			name: 'hide',
+			description: 'Hides the output',
+			type: ApplicationCommandOptionType.Boolean,
+		},
+	],
+} as const;

--- a/src/interactions/utility/refreshscams.ts
+++ b/src/interactions/utility/refreshscams.ts
@@ -1,0 +1,13 @@
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+
+export const RefreshScamlistCommand = {
+	name: 'refreshscams',
+	description: 'Refresh scamlist',
+	options: [
+		{
+			name: 'replace',
+			description: 'If enabled, empties cache before refreshing',
+			type: ApplicationCommandOptionType.Boolean,
+		},
+	],
+} as const;

--- a/src/jobs/scamDomainUpdateTimers.ts
+++ b/src/jobs/scamDomainUpdateTimers.ts
@@ -31,6 +31,9 @@ logger.info(
 	},
 	'Scam domains updated',
 );
+
+await redis.set('scamdomains:refresh', Date.now());
+
 if (parentPort) {
 	parentPort.postMessage('done');
 } else {


### PR DESCRIPTION
- add command to manually check strings against known domains, providing information (amount of known domains, last update) in the response
- add command to manually refresh scam domains (option to delete the cache to get rid of false flags, if necessary)