### PR TITLE
fix(history): correct key for i18n string replace

### DIFF
--- a/src/util/generateHistory.ts
+++ b/src/util/generateHistory.ts
@@ -155,7 +155,7 @@ export async function generateHistory(
 	}
 	if (truncated) {
 		embed = {
-			description: i18next.t('log.history.summary_truncated', { summary_truncated: summary.join('\n'), lng: locale }),
+			description: i18next.t('log.history.summary_truncated', { summary: summary.join('\n'), lng: locale }),
 			...embed,
 		};
 	} else {


### PR DESCRIPTION
This fixes a bug where long descriptions for case history that need to be truncated do not show the truncated history due to a mismatch of the provided `summary_truncated` and expected `summary` key in i18n.