### PR TITLE
fix(antiscam): debug commands should be mod locked

### DIFF
--- a/src/commands/utility/checkScam.ts
+++ b/src/commands/utility/checkScam.ts
@@ -10,6 +10,7 @@ import { kRedis } from '../../tokens';
 import { checkScam } from '../../functions/anti-scam/checkScam';
 import { addFields, truncateEmbed } from '../../util/embed';
 import type { APIEmbed } from 'discord-api-types';
+import { checkModRole } from '../../functions/permissions/checkModRole';
 
 export default class implements Command {
 	public async execute(
@@ -18,6 +19,10 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const redis = container.resolve<Redis>(kRedis);
+
+		await interaction.deferReply({ ephemeral: args.hide ?? true });
+		await checkModRole(interaction, locale);
+
 		const domains = await checkScam(args.content);
 		const cardinality = await redis.scard('scamdomains');
 		const lastRefresh = await redis.get('scamdomains:refresh');
@@ -50,8 +55,6 @@ export default class implements Command {
 				value: domains.map((domain) => `• \`${domain}\``).join('\n'),
 			});
 		}
-
-		await interaction.deferReply({ ephemeral: args.hide ?? true });
 
 		await interaction.editReply({ embeds: [truncateEmbed(embed)] });
 	}

--- a/src/commands/utility/refreshscams.ts
+++ b/src/commands/utility/refreshscams.ts
@@ -10,6 +10,7 @@ import fetch, { Response } from 'node-fetch';
 
 import { kRedis } from '../../tokens';
 import { logger } from '../../logger';
+import { checkModRole } from '../../functions/permissions/checkModRole';
 
 export function checkResponse(response: Response) {
 	if (response.ok) return response;
@@ -24,7 +25,9 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const redis = container.resolve<Redis>(kRedis);
+
 		await interaction.deferReply({ ephemeral: true });
+		await checkModRole(interaction, locale);
 
 		if (!process.env.SCAM_DOMAIN_URL) {
 			logger.warn('Missing environment variable: SCAM_DOMAIN_URL.');

--- a/src/interactions/utility/checkScam.ts
+++ b/src/interactions/utility/checkScam.ts
@@ -16,4 +16,5 @@ export const CheckScamCommand = {
 			type: ApplicationCommandOptionType.Boolean,
 		},
 	],
+	default_permission: false,
 } as const;

--- a/src/interactions/utility/refreshscams.ts
+++ b/src/interactions/utility/refreshscams.ts
@@ -10,4 +10,5 @@ export const RefreshScamlistCommand = {
 			type: ApplicationCommandOptionType.Boolean,
 		},
 	],
+	default_permission: false,
 } as const;


### PR DESCRIPTION
The antiscam debug commands introduced in #1022 should be permission locked to prevent abuse and because they should generally not be used by regular users to potentially scope validation

⚠️ This PR requires a command re-deploy