### PR TITLE
chore(constants): adapt thresholds and expire timers

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -5,12 +5,12 @@ export const enum JobType {
 }
 
 export const MAX_TRUST_ACCOUNT_AGE = 1000 * 60 * 60 * 24 * 7 * 4;
-export const SPAM_THRESHOLD = 5;
-export const SPAM_EXPIRE_SECONDS = 20;
+export const SPAM_THRESHOLD = 4;
+export const SPAM_EXPIRE_SECONDS = 30;
 export const MENTION_THRESHOLD = 10;
-export const MENTION_EXPIRE_SECONDS = 20;
+export const MENTION_EXPIRE_SECONDS = 60;
 export const SCAM_THRESHOLD = 3;
-export const SCAM_EXPIRE_SECONDS = 20;
+export const SCAM_EXPIRE_SECONDS = 5 * 60;
 
 export const DATE_FORMAT_LOGFILE = 'YYYY-MM-DD_HH-mm-ss';
 


### PR DESCRIPTION
Tests have shown that yuudachi missing scams seems to be predominantly caused by the compromised account drip-feeding messages with longer breaks, exceeding the current scam timeout.

This PR addresses this ongoing issue by adapting various constants to be much stricter in order to prevent slower spam and scam attempts.