### PR TITLE
fix(antiscam): improve robustness against false positives

### DIFF
--- a/src/functions/anti-scam/checkScam.ts
+++ b/src/functions/anti-scam/checkScam.ts
@@ -38,7 +38,9 @@ export async function checkScam(content: string): Promise<string[]> {
 		try {
 			const r = await resolveRedirect(url.href);
 			const resolved = urlOption(r);
-			if (!resolved) continue;
+			if (!resolved) {
+				continue;
+			}
 
 			const hit = scamDomains.find((domain) => resolved.host.endsWith(domain));
 

--- a/src/functions/anti-scam/checkScam.ts
+++ b/src/functions/anti-scam/checkScam.ts
@@ -24,7 +24,7 @@ export async function checkScam(content: string): Promise<string[]> {
 		}
 
 		try {
-			const r = await resolveRedirect(matches[0]);
+			const r = await resolveRedirect(url.href);
 			const resolved = new URL(r);
 			const hit = scamDomains.find((domain) => resolved.host.endsWith(domain));
 

--- a/src/functions/anti-scam/checkScam.ts
+++ b/src/functions/anti-scam/checkScam.ts
@@ -14,6 +14,10 @@ function urlOption(url: string): URL | null {
 	}
 }
 
+function checkAgainst(url: URL, host: string) {
+	return `.${url.host}`.endsWith(`.${host}`);
+}
+
 export async function checkScam(content: string): Promise<string[]> {
 	const redis = container.resolve<Redis>(kRedis);
 
@@ -28,7 +32,7 @@ export async function checkScam(content: string): Promise<string[]> {
 			continue;
 		}
 
-		const hit = scamDomains.find((d) => url.host.endsWith(d));
+		const hit = scamDomains.find((d) => checkAgainst(url, d));
 
 		if (hit) {
 			trippedDomains.push(hit);
@@ -42,7 +46,7 @@ export async function checkScam(content: string): Promise<string[]> {
 				continue;
 			}
 
-			const hit = scamDomains.find((domain) => resolved.host.endsWith(domain));
+			const hit = scamDomains.find((d) => checkAgainst(resolved, d));
 
 			if (hit) {
 				trippedDomains.push(hit);


### PR DESCRIPTION
We know of a scam domain called `discordapp.co`, making legit discord CDN links to `discordapp.com` trip under the current system. This proposal fixes this specific issue and makes our approach more robust against other types of false positives.

- use the native `URL` class as parser to extract host (including subdomain)
- use `#endsWith` to be robust against subdomain evasion
- prefix both the host of the domain as well as the scam host with `.` to prevent substrings from tripping (e.g. `idscord.com` would fail with just `#endsWith`)
- use a stricter regular expression, so only embedded links trip the regex (preventing us from checking and redirect-fetching `a.b.` or similar from conversations centered around code)

**Addressing Reviews:**
- I did not implement the proposal to split by space characters instead of using a regular expression, because prefixing domains could potentially evade this system very easily, while still having it embed and be clickable in discord. The regex does not seem to be a large overhead here, though better performance can be a goal to look into in the future