### PR TITLE
fix(timeouts): handle history for timeouts

### DIFF
--- a/src/util/generateHistory.ts
+++ b/src/util/generateHistory.ts
@@ -22,7 +22,7 @@ import { kSQL } from '../tokens';
 import { addFields, truncateEmbed } from './embed';
 import { generateMessageLink } from './generateMessageLink';
 
-const ACTION_KEYS = ['restriction', '', 'warn', 'kick', 'softban', 'ban', 'unban', 'timeout'];
+const ACTION_KEYS = ['restriction', '', 'warn', 'kick', 'softban', 'ban', 'unban', 'timeout', ''];
 
 interface CaseFooter {
 	warn?: number;
@@ -100,7 +100,7 @@ export async function generateHistory(
 			from cases
 			where guild_id = ${interaction.guildId}
 				and target_id = ${target.user.id}
-				and action not in (1)
+				and action not in (1, 8)
 			order by created_at desc`;
 
 	const footer = cases.reduce((count: CaseFooter, c) => {


### PR DESCRIPTION
The change to log timeout expiration has made the handling of this case type in history generation necessary. The initial PR has not covered this case, resulting in a command error when pulling the history of a user that has been timed out before.

- empty fallback analogue to unrole
- ignore in history to not clutter the list analogue to unrole