### PR TITLE
fix(lockdown): channel_types has to be array

### DIFF
--- a/src/interactions/moderation/lockdown.ts
+++ b/src/interactions/moderation/lockdown.ts
@@ -28,7 +28,7 @@ export const LockdownCommand = {
 					name: 'channel',
 					description: 'The channel to lock',
 					type: ApplicationCommandOptionType.Channel,
-					channel_types: ChannelType.GuildText,
+					channel_types: [ChannelType.GuildText],
 				},
 				{
 					name: 'reason',
@@ -46,7 +46,7 @@ export const LockdownCommand = {
 					name: 'channel',
 					description: 'The channel to lift the lock',
 					type: ApplicationCommandOptionType.Channel,
-					channel_types: ChannelType.GuildText,
+					channel_types: [ChannelType.GuildText],
 				},
 			],
 		},


### PR DESCRIPTION
As per documentation <https://discord.com/developers/docs/interactions/application-commands> `channel_types` has to be an array. This restriction is currently ignored, because a number is provided, offering non-text channels for selection.