### PR TITLE
feat(antiSpam): fuzzy hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"bree": "^6.3.0",
 		"bufferutil": "^4.0.3",
 		"common-tags": "^1.8.0",
+		"ctph.js": "^0.0.5",
 		"dayjs": "^1.10.6",
 		"diff": "^5.0.0",
 		"discord.js": "^13.4.0",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -7,6 +7,7 @@ export const enum JobType {
 export const MAX_TRUST_ACCOUNT_AGE = 1000 * 60 * 60 * 24 * 7 * 4;
 export const SPAM_THRESHOLD = 4;
 export const SPAM_EXPIRE_SECONDS = 30;
+export const SPAM_SIMILARITY_THRESHOLD = 70;
 export const MENTION_THRESHOLD = 10;
 export const MENTION_EXPIRE_SECONDS = 60;
 export const SCAM_THRESHOLD = 3;

--- a/src/functions/anti-spam/totalContents.ts
+++ b/src/functions/anti-spam/totalContents.ts
@@ -1,18 +1,28 @@
 import type { Redis } from 'ioredis';
 import { container } from 'tsyringe';
-import { createHash } from 'crypto';
+import { digest, similarity } from 'ctph.js';
 
 import { kRedis } from '../../tokens';
-import { SPAM_EXPIRE_SECONDS } from '../../Constants';
+import { SPAM_EXPIRE_SECONDS, SPAM_SIMILARITY_THRESHOLD } from '../../Constants';
 
 export async function totalContent(content: string, guildId: string, userId: string): Promise<number> {
 	const redis = container.resolve<Redis>(kRedis);
+	const contentHash = digest(content);
 
-	// TODO: fuzzy hashing to combat spam bots that slightly vary content
+	const channelSpamKey = `guild:${guildId}:user:${userId}:spamCount`;
+	const channelHashKey = `guild:${guildId}:user:${userId}:contenthash`;
+	
+	const lastHash = await redis.get(channelHashKey);
+	const similarity = lastHash ? similarity(contentHash, lastHash) > SPAM_SIMILARITY_THRESHOLD : false;
 
-	const contentHash = createHash('md5').update(content.toLowerCase()).digest('hex');
-	const channelSpamKey = `guild:${guildId}:user:${userId}:contenthash:${contentHash}`;
-	const total = await redis.incr(channelSpamKey);
-	await redis.expire(channelSpamKey, SPAM_EXPIRE_SECONDS);
-	return total;
+	if (!lastHash) await redis.set(channelHashKey, contentHash, 'EX', SPAM_EXPIRE_SECONDS);
+
+	if (similarity) {
+			const total = await redis.incr(channelSpamKey);
+			await redis.expire(channelSpamKey, SPAM_EXPIRE_SECONDS);
+			return total;
+	};
+	
+	return 0;
+
 }

--- a/src/functions/anti-spam/totalContents.ts
+++ b/src/functions/anti-spam/totalContents.ts
@@ -22,7 +22,8 @@ export async function totalContent(content: string, guildId: string, userId: str
 			await redis.expire(channelSpamKey, SPAM_EXPIRE_SECONDS);
 			return total;
 	};
-	
-	return 0;
+
+	const total = await redis.get(channelSpamKey) || 0;
+	return total;
 
 }

--- a/src/functions/anti-spam/totalContents.ts
+++ b/src/functions/anti-spam/totalContents.ts
@@ -24,6 +24,7 @@ export async function totalContent(content: string, guildId: string, userId: str
 	};
 
 	const total = await redis.get(channelSpamKey) || 0;
+	
 	return total;
 
 }


### PR DESCRIPTION
This PR uses the old but good `ctph.js` library to prevent bots that slightly vary the message content.

I wasn't able to test this PR because IDK how Yuudachi works (sorry), but for what I used on my own bot, this should work, the other maintainers are much better than me at this, so feel free to edit this PR as much as you want!

> Link to the ctph.js library used here: https://www.npmjs.com/package/ctph.js