### PR TITLE
fix(scamspam): delete keys to prevent re-action after false positive unban

### DIFF
--- a/src/events/anti-scam/messageCreate.ts
+++ b/src/events/anti-scam/messageCreate.ts
@@ -68,6 +68,8 @@ export default class implements Event {
 						deleteMessageDays: 1,
 					});
 
+					const scamKey = `guild:${message.guildId}:user:${message.author.id}:scams`;
+					await this.redis.del(scamKey);
 					await upsertCaseLog(message.guildId, this.client.user, case_);
 				}
 			} catch (e) {

--- a/src/functions/anti-spam/totalContents.ts
+++ b/src/functions/anti-spam/totalContents.ts
@@ -5,12 +5,14 @@ import { createHash } from 'crypto';
 import { kRedis } from '../../tokens';
 import { SPAM_EXPIRE_SECONDS } from '../../Constants';
 
+export function createContentHash(content: string) {
+	return createHash('md5').update(content.toLowerCase()).digest('hex');
+}
+
 export async function totalContent(content: string, guildId: string, userId: string): Promise<number> {
 	const redis = container.resolve<Redis>(kRedis);
 
-	// TODO: fuzzy hashing to combat spam bots that slightly vary content
-
-	const contentHash = createHash('md5').update(content.toLowerCase()).digest('hex');
+	const contentHash = createContentHash(content);
 	const channelSpamKey = `guild:${guildId}:user:${userId}:contenthash:${contentHash}`;
 	const total = await redis.incr(channelSpamKey);
 	await redis.expire(channelSpamKey, SPAM_EXPIRE_SECONDS);


### PR DESCRIPTION
If the user writes a message on the server (not containing scam domains) after being banned and unbanned for a false positive scam attempt flag, the user is immediately re-banned, because the key still exists and is checked on the new message.

This PR attempts to remove this issue by deleting the respective redis keys after a ban/softban for exceeding scam/ban thresholds.

- To facilitate this change I also make the creation of the hash key a reusable utility function, to be consistent across context