### PR TITLE
chore(lockdown): change sentence structure to fit timestamp layout

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -199,7 +199,7 @@
 						"cancel": "Cancel",
 						"execute": "Lock"
 					},
-					"message": "This channel has been locked due to moderation, it will be unlocked in {{- duration}}",
+					"message": "This channel has been locked due to moderation, it will be unlocked {{- duration}}",
 					"cancel": "Cancelled locking of {{- channel}}",
 					"success": "Successfully locked {{- channel}}"
 				},


### PR DESCRIPTION
To grammatically make sense, the `in` is redundant, as it's already included in native Discord timestamps, if the timestamp is in the future. 