### PR TITLE
feat(logs): ignore channels via guild settings

### DIFF
--- a/migrations/1625779687-logfilters.js
+++ b/migrations/1625779687-logfilters.js
@@ -1,0 +1,6 @@
+export async function up(sql) {
+	await sql.unsafe(`
+		alter table guild_settings
+			add column log_ignore_channels text[] not null default '{}'::text[]
+	`);
+}

--- a/src/events/guild-log/messageDelete.ts
+++ b/src/events/guild-log/messageDelete.ts
@@ -39,6 +39,7 @@ export default class implements Event {
 				if (!logChannelId) {
 					continue;
 				}
+				// TODO: ignore based on parent category once .inGuild() is available
 				if (
 					(message.channel.isThread() && ignoreChannels.includes(message.channel.parentId)) ||
 					ignoreChannels.includes(message.channelId)

--- a/src/events/guild-log/messageDelete.ts
+++ b/src/events/guild-log/messageDelete.ts
@@ -33,6 +33,19 @@ export default class implements Event {
 			}
 
 			try {
+				const locale = await getGuildSetting(message.guild.id, SettingsKeys.Locale);
+				const logChannelId = await getGuildSetting(message.guild.id, SettingsKeys.GuildLogWebhookId);
+				const ignoreChannels = await getGuildSetting(message.guild.id, SettingsKeys.LogIgnoreChannels);
+				if (!logChannelId) {
+					continue;
+				}
+				if (
+					(message.channel.isThread() && ignoreChannels.includes(message.channel.parentId)) ||
+					ignoreChannels.includes(message.channelId)
+				) {
+					continue;
+				}
+
 				logger.info(
 					{
 						event: { name: this.name, event: this.event },
@@ -42,11 +55,6 @@ export default class implements Event {
 					`Member ${message.author.id} deleted a message`,
 				);
 
-				const locale = await getGuildSetting(message.guild.id, SettingsKeys.Locale);
-				const logChannelId = await getGuildSetting(message.guild.id, SettingsKeys.GuildLogWebhookId);
-				if (!logChannelId) {
-					continue;
-				}
 				const webhook = this.webhooks.get(logChannelId);
 				if (!webhook) {
 					continue;

--- a/src/events/guild-log/messageDeleteBulk.ts
+++ b/src/events/guild-log/messageDeleteBulk.ts
@@ -35,16 +35,26 @@ export default class implements Event {
 			if (!messages.size) {
 				continue;
 			}
-			if (messages.first()!.author.bot) {
+			const message = messages.first() as Message;
+			if (message.author.bot) {
 				continue;
 			}
-			if (!messages.first()!.guild) {
+			if (message.guild) {
 				continue;
 			}
 
 			try {
 				const locale = await getGuildSetting(messages.first()!.guild!.id, SettingsKeys.Locale);
 				const logChannelId = await getGuildSetting(messages.first()!.guild!.id, SettingsKeys.GuildLogWebhookId);
+				const ignoreChannels = await getGuildSetting(message.guild!.id, SettingsKeys.LogIgnoreChannels);
+
+				if (
+					(message.channel.isThread() && ignoreChannels.includes(message.channel.parentId)) ||
+					ignoreChannels.includes(message.channelId)
+				) {
+					continue;
+				}
+
 				if (!logChannelId) {
 					continue;
 				}

--- a/src/events/guild-log/messageDeleteBulk.ts
+++ b/src/events/guild-log/messageDeleteBulk.ts
@@ -47,7 +47,7 @@ export default class implements Event {
 				const locale = await getGuildSetting(messages.first()!.guild!.id, SettingsKeys.Locale);
 				const logChannelId = await getGuildSetting(messages.first()!.guild!.id, SettingsKeys.GuildLogWebhookId);
 				const ignoreChannels = await getGuildSetting(message.guild!.id, SettingsKeys.LogIgnoreChannels);
-
+				// TODO: ignore based on parent category once .inGuild() is available
 				if (
 					(message.channel.isThread() && ignoreChannels.includes(message.channel.parentId)) ||
 					ignoreChannels.includes(message.channelId)

--- a/src/events/guild-log/messageUpdate.ts
+++ b/src/events/guild-log/messageUpdate.ts
@@ -36,6 +36,20 @@ export default class implements Event {
 			}
 
 			try {
+				const locale = await getGuildSetting(newMessage.guild.id, SettingsKeys.Locale);
+				const logChannelId = await getGuildSetting(newMessage.guild.id, SettingsKeys.GuildLogWebhookId);
+				const ignoreChannels = await getGuildSetting(newMessage.guild.id, SettingsKeys.LogIgnoreChannels);
+
+				if (!logChannelId) {
+					continue;
+				}
+				if (
+					(newMessage.channel.isThread() && ignoreChannels.includes(newMessage.channel.parentId)) ||
+					ignoreChannels.includes(newMessage.channelId)
+				) {
+					continue;
+				}
+
 				logger.info(
 					{
 						event: { name: this.name, event: this.event },
@@ -45,11 +59,6 @@ export default class implements Event {
 					`Member ${newMessage.author.id} updated a message`,
 				);
 
-				const locale = await getGuildSetting(newMessage.guild.id, SettingsKeys.Locale);
-				const logChannelId = await getGuildSetting(newMessage.guild.id, SettingsKeys.GuildLogWebhookId);
-				if (!logChannelId) {
-					continue;
-				}
 				const webhook = this.webhooks.get(logChannelId);
 				if (!webhook) {
 					continue;

--- a/src/functions/settings/getGuildSetting.ts
+++ b/src/functions/settings/getGuildSetting.ts
@@ -10,6 +10,7 @@ export enum SettingsKeys {
 	GuildLogWebhookId = 'guild_log_webhook_id',
 	MemberLogWebhookId = 'member_log_webhook_id',
 	Locale = 'locale',
+	LogIgnoreChannels = 'log_ignore_channels',
 }
 
 export async function getGuildSetting(guildId: Snowflake, prop: SettingsKeys, table = 'guild_settings') {


### PR DESCRIPTION
Proposal to introduce the ability to ignore channels via guild settings
### Voice channels
- joins into ignored channels are ignored
- moves into ignored channels are logged as a leave of the previous channel
- moves out of ignored channels are logged as a join of the new channel
- leaves out of ignored channels are ignored

### Text channels
- are ignored via ID
- ignore via category channel will be added at a later date, once the code base is updated to the point where `#inGuild` is available. Checking for guild-based channels is currently a massive hassle.

### Thread channels
- are ignored via ID
- are ignored if the parent is ignored