### PR TITLE
feat(lockdowns): reason, error prevention

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -192,7 +192,8 @@
 				"lock": {
 					"errors": {
 						"missing_permissions": "Missing permissions to lock {{- channel}}",
-						"already_locked": "{{- channel}} is already locked."
+						"already_locked": "{{- channel}} is already locked.",
+						"bot_requires_admin": "The bot requires the `ADMINISTRATOR` permission to lock down channels as Discord does not allow setting all overwrites without it, potentially causing issues when locking or unlocking."
 					},
 					"pending": "Do you really want to lock {{- channel}}?",
 					"buttons": {

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -199,7 +199,8 @@
 						"cancel": "Cancel",
 						"execute": "Lock"
 					},
-					"message": "This channel has been locked due to moderation, it will be unlocked {{- duration}}",
+					"message": "🔒 This channel has been locked, it will be unlocked {{- duration}}",
+					"message_reason": "🔒 This channel has been locked with reason {{- reason}}, it will be unlocked {{- duration}}",
 					"cancel": "Cancelled locking of {{- channel}}",
 					"success": "Successfully locked {{- channel}}"
 				},

--- a/src/commands/moderation/lockdown.ts
+++ b/src/commands/moderation/lockdown.ts
@@ -19,6 +19,14 @@ export default class implements Command {
 		const reply = await interaction.deferReply({ ephemeral: true, fetchReply: true });
 		await checkModRole(interaction, locale);
 
+		if (!interaction.guild.me?.permissions.has(PermissionFlagsBits.Administrator)) {
+			throw new Error(
+				i18next.t('command.mod.lockdown.lock.errors.bot_requires_admin', {
+					lng: locale,
+				}),
+			);
+		}
+
 		switch (Object.keys(args)[0]) {
 			case 'lock': {
 				if (args.lock.channel && !args.lock.channel.isText()) {

--- a/src/commands/moderation/sub/lockdown/lock.ts
+++ b/src/commands/moderation/sub/lockdown/lock.ts
@@ -98,10 +98,16 @@ export async function lock(
 		});
 
 		await args.channel.send({
-			content: i18next.t('command.mod.lockdown.lock.message', {
-				duration: Formatters.time(dayjs(duration.toISOString()).unix(), Formatters.TimestampStyles.RelativeTime),
-				lng: locale,
-			}),
+			content: args.reason
+				? i18next.t('command.mod.lockdown.lock.message_reason', {
+						duration: Formatters.time(dayjs(duration.toISOString()).unix(), Formatters.TimestampStyles.RelativeTime),
+						reason: Formatters.inlineCode(args.reason),
+						lng: locale,
+				  })
+				: i18next.t('command.mod.lockdown.lock.message', {
+						duration: Formatters.time(dayjs(duration.toISOString()).unix(), Formatters.TimestampStyles.RelativeTime),
+						lng: locale,
+				  }),
 		});
 
 		await collectedInteraction.editReply({

--- a/src/functions/lockdowns/deleteLockdown.ts
+++ b/src/functions/lockdowns/deleteLockdown.ts
@@ -19,12 +19,14 @@ export async function deleteLockdown(channelId: Snowflake) {
 		return null;
 	}
 
-	await channel.permissionOverwrites.set(channelOverwrites.overwrites);
-
-	await sql`
-		delete
-		from lockdowns
-		where channel_id = ${channel.id}`;
+	try {
+		await channel.permissionOverwrites.set(channelOverwrites.overwrites);
+	} finally {
+		await sql`
+			delete
+			from lockdowns
+			where channel_id = ${channel.id}`;
+	}
 
 	return channel.id;
 }

--- a/src/jobs/modLockdownTimers.ts
+++ b/src/jobs/modLockdownTimers.ts
@@ -22,7 +22,7 @@ const currentLockdowns = await sql<[{ channel_id: Snowflake; expiration: string 
 for (const lockdown of currentLockdowns) {
 	if (Date.parse(lockdown.expiration) <= Date.now()) {
 		if (parentPort) {
-			parentPort.postMessage({ op: JobType.Case, d: { channelId: lockdown.channel_id } });
+			parentPort.postMessage({ op: JobType.Lockdown, d: { channelId: lockdown.channel_id } });
 		}
 	}
 }


### PR DESCRIPTION
- use reason in the public-facing message, omit completely if no reason is set ("due to moderation" is not informative)
- use the proper JobType key, which caused the lockdown to error on lift attempt
- resolve the case even if the lifting errors (this used to cause errors on every job cycle, because of missing permissions)
- inform of missing permissions if the bot is not an administrator

Note: The bot requires the `ADMINISTRATOR` permission to use lockdown, this is due to Discord not allowing bots to set the `MANAGE_ROLES` permission, if the user is not an administrator. This causes issues with the way lockdowns work (removing overwrites, saving them, and setting them in place again after the lockdown duration is over). 