### PR TITLE
feat(antiscam): use discord bad domains as secondary scam domain check

### DIFF
--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -34,6 +34,14 @@ export function registerJobs() {
 		timeout: 0,
 		path: fileURLToPath(new URL('./jobs/scamDomainUpdateTimers.js', import.meta.url)),
 	});
+
+	logger.info({ job: { name: 'discordScamDomainUpdateTimers' } }, 'Registering job: discordScamDomainUpdateTimers');
+	bree.add({
+		name: 'discordScamDomainUpdateTimers',
+		interval: '5m',
+		timeout: 0,
+		path: fileURLToPath(new URL('./jobs/discordScamDomainUpdateTimers.js', import.meta.url)),
+	});
 }
 
 export function startJobs() {

--- a/src/jobs/discordScamDomainUpdateTimers.ts
+++ b/src/jobs/discordScamDomainUpdateTimers.ts
@@ -1,0 +1,41 @@
+import fetch, { Response } from 'node-fetch';
+import { parentPort } from 'node:worker_threads';
+import Redis from 'ioredis';
+
+import { logger } from '../logger';
+
+function checkResponse(response: Response) {
+	if (response.ok) return response;
+	logger.warn({ response }, 'Fetching discord scam domain hashes returned a non 2xx response code.');
+	process.exit(1);
+}
+
+const redis = new Redis(process.env.REDISHOST);
+
+if (!process.env.SCAM_DOMAIN_DISCORD_URL) {
+	logger.warn('Missing environment variable: SCAM_DOMAIN_DISCORD_URL.');
+	process.exit(1);
+}
+
+const list = await fetch(process.env.SCAM_DOMAIN_DISCORD_URL)
+	.then(checkResponse)
+	.then((r) => r.json());
+const before = await redis.scard('scamdomains_discord');
+await redis.del('scamdomains_discord');
+await redis.sadd('scamdomains_discord', ...list);
+const after = await redis.scard('scamdomains_discord');
+logger.info(
+	{
+		before,
+		after,
+	},
+	'Discord Scam domain hashes updated (replaced)',
+);
+
+await redis.set('scamdomains_discord:refresh', Date.now());
+
+if (parentPort) {
+	parentPort.postMessage('done');
+} else {
+	process.exit(0);
+}


### PR DESCRIPTION
Use the bad domain list the Discord client pulls as a secondary resource to determine scam domains, if the phish project did not produce a hit.

⚠️ This requires a new environment variable `SCAM_DOMAIN_DISCORD_URL`