### PR TITLE
feat(anti-raid-nuke): allow filtering by avatar hash

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -116,6 +116,7 @@
 						"join_after": "• Join date after: {{- join}}",
 						"created_after": "• Account creation after: {{- age}}",
 						"pattern": "• Username matching pattern:",
+						"avatar": "• Avatar hash (user or member) matching: {{- avatar}}",
 						"days": "• Deleting messages sent in the last {{count}} day",
 						"days_plural": "• Deleting messages sent in the last {{count}} days",
 						"days_none": "• Not deleting any messages"

--- a/src/commands/moderation/anti-raid-nuke.ts
+++ b/src/commands/moderation/anti-raid-nuke.ts
@@ -76,6 +76,13 @@ export default class implements Command {
 					}
 				} catch {}
 			}
+
+			if (args.avatar) {
+				if (member.avatar !== args.avatar && member.user.avatar !== args.avatar) {
+					return false;
+				}
+			}
+
 			return member.joinedTimestamp! > joinCutoff && member.user.createdTimestamp > accountCutoff;
 		});
 
@@ -96,6 +103,15 @@ export default class implements Command {
 				age: Formatters.time(dayjs(accountCutoff).unix(), Formatters.TimestampStyles.ShortDateTime),
 			}),
 		];
+
+		if (args.avatar) {
+			parameterStrings.push(
+				i18next.t('command.mod.anti_raid_nuke.errors.parameters.avatar', {
+					avatar: Formatters.inlineCode(args.avatar),
+					lng: locale,
+				}),
+			);
+		}
 
 		if (args.pattern) {
 			parameterStrings.push(

--- a/src/interactions/moderation/anti-raid-nuke.ts
+++ b/src/interactions/moderation/anti-raid-nuke.ts
@@ -22,6 +22,11 @@ export const AntiRaidNukeCommand = {
 			type: ApplicationCommandOptionType.String,
 		},
 		{
+			name: 'avatar',
+			description: 'The avatar hash the user or member should have (exact match)',
+			type: ApplicationCommandOptionType.String,
+		},
+		{
 			name: 'reason',
 			description: 'The reason of this action',
 			type: ApplicationCommandOptionType.String,


### PR DESCRIPTION
We have experienced raiders before that were drip-fed into the server over months, then all changed their avatars and stared to DM-spam members. This PR adds the ability to filter for avatar hash (global and guild-based) matches in the anti raid nuke command.

⚠️ this requires re-deploying commands, because an option was added to "anti-raid-nuke"