### PR TITLE
fix(lockdown): handle deleted target channel

### DIFF
--- a/src/functions/lockdowns/deleteLockdown.ts
+++ b/src/functions/lockdowns/deleteLockdown.ts
@@ -8,25 +8,25 @@ export async function deleteLockdown(channelId: Snowflake) {
 	const client = container.resolve<Client<true>>(Client);
 	const sql = container.resolve<Sql<any>>(kSQL);
 
-	const channel = (await client.channels.fetch(channelId)) as GuildChannel;
-
-	const [channelOverwrites] = await sql<[{ overwrites: PermissionOverwrites[] }?]>`
-		select overwrites
-		from lockdowns
-		where channel_id = ${channel.id}`;
-
-	if (!channelOverwrites) {
-		return null;
-	}
-
 	try {
+		const channel = (await client.channels.fetch(channelId)) as GuildChannel;
+
+		const [channelOverwrites] = await sql<[{ overwrites: PermissionOverwrites[] }?]>`
+			select overwrites
+			from lockdowns
+			where channel_id = ${channel.id}`;
+
+		if (!channelOverwrites) {
+			return null;
+		}
+
 		await channel.permissionOverwrites.set(channelOverwrites.overwrites);
 	} finally {
 		await sql`
 			delete
 			from lockdowns
-			where channel_id = ${channel.id}`;
+			where channel_id = ${channelId}`;
 	}
 
-	return channel.id;
+	return channelId;
 }


### PR DESCRIPTION
If a channel is deleted before the lockdown is resolved, the current setup causes errors on each check cycle, due to failure of channel fetching. 

This PR attempts to fix this by including the fetching in the try body and resolving the lockdown regardless.