### PR TITLE
feat(softban): allow non-members to be softbanned

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -74,12 +74,19 @@
 					"missing_permissions": "Missing permissions to softban {{- user}}"
 				},
 				"pending": "Do you really want to softban {{- user}}?",
+				"not_member": "User {{- user}} is not on this guild. Do you still wish to softban them to remove messages?",
 				"buttons": {
 					"cancel": "Cancel",
 					"execute": "Softban"
 				},
+				"reasons": {
+					"clear_messages": "Mod: {{- user}} | Softban to clear messages"
+				},
 				"cancel": "Cancelled softban on {{- user}}",
-				"success": "Successfully softbanned {{- user}}"
+				"success": {
+					"regular": "Successfully softbanned {{- user}}",
+					"clear_messages": "Successfully cleared messages by {{- user}}"
+				}
 			},
 			"ban": {
 				"errors": {


### PR DESCRIPTION
- No longer throw if the member is not on the guild anymore
- Update the prompt to reflect that the member is no longer on the guild, if applicable
- Do not generate a case if the member is not on the guild
- Update success messages with a branch for the clearing action

This setup serves two purposes:

1. Alert the moderator issuing a softban that the member is already gone (potentially to dodge the hammer, potentially because someone else already actioned them), allowing them to cancel out and re-assess the situation
2. Allow clearing messages of people that have left the server already/have been kicked or banned without specifying the `days` option by accident

A nice side-effect is no longer getting "missing permissions" when that was not the case to begin with (`.bannable` failed because the user was no longe ron the guild, due to the `.manageable` portion of that utility method)