### PR TITLE
feat(kick): more verbose error if no longer member

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -59,7 +59,8 @@
 			},
 			"kick": {
 				"errors": {
-					"missing_permissions": "Missing permissions to kick {{- user}}"
+					"missing_permissions": "Missing permissions to kick {{- user}}",
+					"not_member": "User {{- user}} is not on this guild"
 				},
 				"pending": "Do you really want to kick {{- user}}?",
 				"buttons": {

--- a/src/commands/moderation/kick.ts
+++ b/src/commands/moderation/kick.ts
@@ -39,11 +39,15 @@ export default class implements Command {
 		}
 
 		if (!args.user.member?.kickable) {
+			const isStillMember = interaction.guild.members.resolve(args.user.user.id);
 			throw new Error(
-				i18next.t('command.mod.kick.errors.missing_permissions', {
-					user: `${args.user.user.toString()} - ${args.user.user.tag} (${args.user.user.id})`,
-					lng: locale,
-				}),
+				i18next.t(
+					isStillMember ? 'command.mod.kick.errors.missing_permissions' : 'command.mod.kick.errors.not_member',
+					{
+						user: `${args.user.user.toString()} - ${args.user.user.tag} (${args.user.user.id})`,
+						lng: locale,
+					},
+				),
 			);
 		}
 


### PR DESCRIPTION
Currently, users merely get "missing permissions" as a reason, if the user passed to the command is not a user at all or left during command execution. This PR provides a verbose reason for when the user is not on the guild (anymore)