### PR TITLE
feat(commands): perms v2

### DIFF
--- a/src/commands/moderation/anti-raid-nuke.ts
+++ b/src/commands/moderation/anti-raid-nuke.ts
@@ -11,7 +11,6 @@ import { DATE_FORMAT_LOGFILE } from '../../Constants.js';
 import { type Case, CaseAction, createCase } from '../../functions/cases/createCase.js';
 import { generateCasePayload } from '../../functions/logging/generateCasePayload.js';
 import { insertAntiRaidNukeCaseLog } from '../../functions/logging/insertAntiRaidNukeCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -32,8 +31,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply();
-		await checkModRole(interaction, locale);
-
 		const logChannel = await checkLogChannel(
 			interaction.guild,
 			(await getGuildSetting(interaction.guildId, SettingsKeys.ModLogChannelId)) as string,

--- a/src/commands/moderation/ban.ts
+++ b/src/commands/moderation/ban.ts
@@ -7,7 +7,6 @@ import type { Command } from '../../Command.js';
 import { CaseAction, createCase } from '../../functions/cases/createCase.js';
 import { generateCasePayload } from '../../functions/logging/generateCasePayload.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -28,8 +27,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
-
 		const logChannel = await checkLogChannel(
 			interaction.guild,
 			(await getGuildSetting(interaction.guildId, SettingsKeys.ModLogChannelId)) as string,

--- a/src/commands/moderation/case.ts
+++ b/src/commands/moderation/case.ts
@@ -5,7 +5,6 @@ import { container } from 'tsyringe';
 import type { Command } from '../../Command.js';
 import { RawCase, transformCase } from '../../functions/cases/transformCase.js';
 import { generateCaseEmbed } from '../../functions/logging/generateCaseEmbed.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -91,7 +90,6 @@ export default class implements Command {
 	): Promise<void> {
 		const sql = container.resolve<Sql<any>>(kSQL);
 		await interaction.deferReply({ ephemeral: args.hide ?? true });
-		await checkModRole(interaction, locale);
 
 		const [cmd, id] = args.phrase.split(OP_DELIMITER);
 		if (cmd === 'history' && id) {

--- a/src/commands/moderation/duration.ts
+++ b/src/commands/moderation/duration.ts
@@ -5,7 +5,6 @@ import type { Command } from '../../Command.js';
 import { getCase } from '../../functions/cases/getCase.js';
 import { updateCase } from '../../functions/cases/updateCase.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -19,8 +18,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
-
 		const logChannel = await checkLogChannel(
 			interaction.guild,
 			(await getGuildSetting(interaction.guildId, SettingsKeys.ModLogChannelId)) as string,

--- a/src/commands/moderation/history.ts
+++ b/src/commands/moderation/history.ts
@@ -1,6 +1,5 @@
 import type { CommandInteraction } from 'discord.js';
 import type { Command } from '../../Command.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
 import type { HistoryCommand } from '../../interactions/index.js';
 import { generateHistory } from '../../util/generateHistory.js';
@@ -12,7 +11,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		await interaction.deferReply({ ephemeral: args.hide ?? true });
-		await checkModRole(interaction, locale);
 
 		const embed = await generateHistory(interaction, args.user, locale);
 

--- a/src/commands/moderation/kick.ts
+++ b/src/commands/moderation/kick.ts
@@ -7,7 +7,6 @@ import type { Command } from '../../Command.js';
 import { createCase, CaseAction } from '../../functions/cases/createCase.js';
 import { generateCasePayload } from '../../functions/logging/generateCasePayload.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -28,7 +27,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const logChannel = await checkLogChannel(
 			interaction.guild,

--- a/src/commands/moderation/lockdown.ts
+++ b/src/commands/moderation/lockdown.ts
@@ -4,7 +4,6 @@ import i18next from 'i18next';
 import { lift } from './sub/lockdown/lift.js';
 import { lock } from './sub/lockdown/lock.js';
 import type { Command } from '../../Command.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
 import type { LockdownCommand } from '../../interactions/index.js';
 
@@ -15,7 +14,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		if (!interaction.guild.members.me?.permissions.has(PermissionFlagsBits.Administrator)) {
 			throw new Error(

--- a/src/commands/moderation/reason.ts
+++ b/src/commands/moderation/reason.ts
@@ -6,7 +6,6 @@ import type { Case } from '../../functions/cases/createCase.js';
 import { getCase } from '../../functions/cases/getCase.js';
 import { updateCase } from '../../functions/cases/updateCase.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -24,7 +23,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const logChannel = await checkLogChannel(
 			interaction.guild,

--- a/src/commands/moderation/reference.ts
+++ b/src/commands/moderation/reference.ts
@@ -4,7 +4,6 @@ import type { Command } from '../../Command.js';
 import { getCase } from '../../functions/cases/getCase.js';
 import { updateCase } from '../../functions/cases/updateCase.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -18,7 +17,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const logChannel = await checkLogChannel(
 			interaction.guild,

--- a/src/commands/moderation/restrict.ts
+++ b/src/commands/moderation/restrict.ts
@@ -5,7 +5,6 @@ import { emoji } from './sub/restrict/emoji.js';
 import { react } from './sub/restrict/react.js';
 import { unrole } from './sub/restrict/unrole.js';
 import type { Command } from '../../Command.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -18,7 +17,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const logChannel = await checkLogChannel(
 			interaction.guild,

--- a/src/commands/moderation/softban.ts
+++ b/src/commands/moderation/softban.ts
@@ -7,7 +7,6 @@ import type { Command } from '../../Command.js';
 import { CaseAction, createCase } from '../../functions/cases/createCase.js';
 import { generateCasePayload } from '../../functions/logging/generateCasePayload.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -28,7 +27,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const logChannel = await checkLogChannel(
 			interaction.guild,

--- a/src/commands/moderation/timeout.ts
+++ b/src/commands/moderation/timeout.ts
@@ -8,7 +8,6 @@ import type { Command } from '../../Command.js';
 import { CaseAction, createCase } from '../../functions/cases/createCase.js';
 import { generateCasePayload } from '../../functions/logging/generateCasePayload.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -29,7 +28,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const logChannel = await checkLogChannel(
 			interaction.guild,

--- a/src/commands/moderation/unban.ts
+++ b/src/commands/moderation/unban.ts
@@ -6,7 +6,6 @@ import { inject, injectable } from 'tsyringe';
 import type { Command } from '../../Command.js';
 import { deleteCase } from '../../functions/cases/deleteCase.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -27,7 +26,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const logChannel = await checkLogChannel(
 			interaction.guild,

--- a/src/commands/moderation/warn.ts
+++ b/src/commands/moderation/warn.ts
@@ -5,7 +5,6 @@ import type { Command } from '../../Command.js';
 import { CaseAction, createCase } from '../../functions/cases/createCase.js';
 import { generateCasePayload } from '../../functions/logging/generateCasePayload.js';
 import { upsertCaseLog } from '../../functions/logging/upsertCaseLog.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
@@ -22,7 +21,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const logChannel = await checkLogChannel(
 			interaction.guild,

--- a/src/commands/utility/checkScam.ts
+++ b/src/commands/utility/checkScam.ts
@@ -3,7 +3,6 @@ import type { CommandInteraction } from 'discord.js';
 import i18next from 'i18next';
 import type { Command } from '../../Command.js';
 import { checkScam } from '../../functions/anti-scam/checkScam.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
 import type { CheckScamCommand } from '../../interactions/index.js';
 import { addFields, truncateEmbed } from '../../util/embed.js';
@@ -15,7 +14,6 @@ export default class implements Command {
 		locale: string,
 	): Promise<void> {
 		await interaction.deferReply({ ephemeral: args.hide ?? true });
-		await checkModRole(interaction, locale);
 
 		const domains = await checkScam(args.content);
 

--- a/src/commands/utility/refreshscams.ts
+++ b/src/commands/utility/refreshscams.ts
@@ -5,7 +5,6 @@ import { nanoid } from 'nanoid';
 import { container } from 'tsyringe';
 import type { Command } from '../../Command.js';
 import { refreshScamDomains, ScamRedisKeys, scamURLEnvs } from '../../functions/anti-scam/refreshScamDomains.js';
-import { checkModRole } from '../../functions/permissions/checkModRole.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
 import type { RefreshScamlistCommand } from '../../interactions/index.js';
 import { logger } from '../../logger.js';
@@ -23,7 +22,6 @@ export default class implements Command {
 		const redis = container.resolve<Redis>(kRedis);
 
 		const reply = await interaction.deferReply({ ephemeral: true });
-		await checkModRole(interaction, locale);
 
 		const missing = scamURLEnvs.filter((u) => !process.env[u]);
 

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,9 +1,5 @@
 import { REST } from '@discordjs/rest';
-import {
-	ApplicationCommandPermissionType,
-	type RESTGetAPIApplicationGuildCommandsResult,
-	Routes,
-} from 'discord-api-types/v10';
+import { Routes } from 'discord-api-types/v10';
 
 import {
 	// Moderation
@@ -36,58 +32,33 @@ const rest = new REST({ version: '9' }).setToken(process.env.DISCORD_TOKEN!);
 try {
 	console.log('Start refreshing interaction (/) commands.');
 
-	const commands = (await rest.put(
-		Routes.applicationGuildCommands(process.env.DISCORD_CLIENT_ID!, process.env.DISCORD_GUILD_ID!),
-		{
-			body: [
-				// Moderation
-				AntiRaidNukeCommand,
-				BanCommand,
-				CaseLookupCommand,
-				DurationCommand,
-				HistoryCommand,
-				KickCommand,
-				ReasonCommand,
-				ReferenceCommand,
-				RestrictCommand,
-				SoftbanCommand,
-				UnbanCommand,
-				WarnCommand,
-				LockdownCommand,
-				TimeoutCommand,
+	await rest.put(Routes.applicationGuildCommands(process.env.DISCORD_CLIENT_ID!, process.env.DISCORD_GUILD_ID!), {
+		body: [
+			// Moderation
+			AntiRaidNukeCommand,
+			BanCommand,
+			CaseLookupCommand,
+			DurationCommand,
+			HistoryCommand,
+			KickCommand,
+			ReasonCommand,
+			ReferenceCommand,
+			RestrictCommand,
+			SoftbanCommand,
+			UnbanCommand,
+			WarnCommand,
+			LockdownCommand,
+			TimeoutCommand,
 
-				// Utility
-				PingCommand,
-				CheckScamCommand,
-				RefreshScamlistCommand,
+			// Utility
+			PingCommand,
+			CheckScamCommand,
+			RefreshScamlistCommand,
 
-				// Context Menu
-				HistoryContextMenuCommand,
-			],
-		},
-	)) as RESTGetAPIApplicationGuildCommandsResult;
-
-	await rest.put(
-		Routes.guildApplicationCommandsPermissions(process.env.DISCORD_CLIENT_ID!, process.env.DISCORD_GUILD_ID!),
-		{
-			body: commands.map((cmd) => ({
-				id: cmd.id,
-				permissions: [
-					{
-						id: process.env.DISCORD_USER_ID!,
-						type: ApplicationCommandPermissionType.User,
-						permission: true,
-					},
-					{
-						id: process.env.DISCORD_MOD_ROLE_ID!,
-						type: ApplicationCommandPermissionType.Role,
-						permission: true,
-					},
-				],
-			})),
-		},
-	);
-
+			// Context Menu
+			HistoryContextMenuCommand,
+		],
+	});
 	console.log('Successfully reloaded interaction (/) commands.');
 } catch (e) {
 	console.error(e);

--- a/src/interactions/context-menu/history.ts
+++ b/src/interactions/context-menu/history.ts
@@ -2,6 +2,6 @@ import { ApplicationCommandType, type RESTPostAPIContextMenuApplicationCommandsJ
 
 export const HistoryContextMenuCommand: RESTPostAPIContextMenuApplicationCommandsJSONBody = {
 	name: 'History',
-	default_permission: false,
+	default_member_permissions: '0',
 	type: ApplicationCommandType.User,
 } as const;

--- a/src/interactions/moderation/anti-raid-nuke.ts
+++ b/src/interactions/moderation/anti-raid-nuke.ts
@@ -47,5 +47,5 @@ export const AntiRaidNukeCommand = {
 			],
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/ban.ts
+++ b/src/interactions/moderation/ban.ts
@@ -36,5 +36,5 @@ export const BanCommand = {
 			type: ApplicationCommandOptionType.Integer,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/case.ts
+++ b/src/interactions/moderation/case.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, PermissionFlagsBits } from 'discord-api-types/v10';
+import { ApplicationCommandOptionType } from 'discord-api-types/v10';
 
 export const CaseLookupCommand = {
 	name: 'case',
@@ -17,5 +17,5 @@ export const CaseLookupCommand = {
 			type: ApplicationCommandOptionType.Boolean,
 		},
 	],
-	default_member_permissions: PermissionFlagsBits.BanMembers.toString(),
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/duration.ts
+++ b/src/interactions/moderation/duration.ts
@@ -26,5 +26,5 @@ export const DurationCommand = {
 			required: true,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/history.ts
+++ b/src/interactions/moderation/history.ts
@@ -16,5 +16,5 @@ export const HistoryCommand = {
 			type: ApplicationCommandOptionType.Boolean,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/kick.ts
+++ b/src/interactions/moderation/kick.ts
@@ -21,5 +21,5 @@ export const KickCommand = {
 			type: ApplicationCommandOptionType.Integer,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/lockdown.ts
+++ b/src/interactions/moderation/lockdown.ts
@@ -51,5 +51,5 @@ export const LockdownCommand = {
 			],
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/reason.ts
+++ b/src/interactions/moderation/reason.ts
@@ -22,5 +22,5 @@ export const ReasonCommand = {
 			type: ApplicationCommandOptionType.Integer,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/reference.ts
+++ b/src/interactions/moderation/reference.ts
@@ -17,5 +17,5 @@ export const ReferenceCommand = {
 			required: true,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/restrict.ts
+++ b/src/interactions/moderation/restrict.ts
@@ -132,5 +132,5 @@ export const RestrictCommand = {
 			],
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/softban.ts
+++ b/src/interactions/moderation/softban.ts
@@ -36,5 +36,5 @@ export const SoftbanCommand = {
 			type: ApplicationCommandOptionType.Integer,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/timeout.ts
+++ b/src/interactions/moderation/timeout.ts
@@ -40,5 +40,5 @@ export const TimeoutCommand = {
 			type: ApplicationCommandOptionType.Integer,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/unban.ts
+++ b/src/interactions/moderation/unban.ts
@@ -21,5 +21,5 @@ export const UnbanCommand = {
 			type: ApplicationCommandOptionType.Integer,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/moderation/warn.ts
+++ b/src/interactions/moderation/warn.ts
@@ -21,5 +21,5 @@ export const WarnCommand = {
 			type: ApplicationCommandOptionType.Integer,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/utility/checkScam.ts
+++ b/src/interactions/utility/checkScam.ts
@@ -16,5 +16,5 @@ export const CheckScamCommand = {
 			type: ApplicationCommandOptionType.Boolean,
 		},
 	],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/utility/ping.ts
+++ b/src/interactions/utility/ping.ts
@@ -10,4 +10,5 @@ export const PingCommand = {
 			type: ApplicationCommandOptionType.Boolean,
 		},
 	],
+	default_member_permissions: '0',
 } as const;

--- a/src/interactions/utility/refreshscams.ts
+++ b/src/interactions/utility/refreshscams.ts
@@ -2,5 +2,5 @@ export const RefreshScamlistCommand = {
 	name: 'refreshscams',
 	description: 'Refresh scamlists',
 	options: [],
-	default_permission: false,
+	default_member_permissions: '0',
 } as const;


### PR DESCRIPTION
- Remove modrole checks (leaving the method itself intact, for possible future plans)
- Disable all commands by default (to then be set up by server staff)
- Remove permission section of deploy code

