### PR TITLE
feat(case): prepend special entry

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -22,3 +22,4 @@ export const EMBED_FIELD_LIMIT = 25;
 export const EMBED_FIELD_NAME_LIMIT = 256;
 export const EMBED_FIELD_VALUE_LIMIT = 1024;
 export const SNOWFLAKE_MIN_LENGTH = 17;
+export const AUTOCOMPLETE_CHOICES_MAX = 25;

--- a/src/commands/moderation/case.ts
+++ b/src/commands/moderation/case.ts
@@ -50,6 +50,9 @@ export default class implements Command {
 			const uniqueTargets = new Collection<string, { id: string; tag: string }>();
 
 			for (const c of cases) {
+				if (uniqueTargets.has(c.target_id)) {
+					continue;
+				}
 				uniqueTargets.set(c.target_id, { id: c.target_id, tag: c.target_tag });
 			}
 
@@ -57,17 +60,17 @@ export default class implements Command {
 				const target = uniqueTargets.first()!;
 				choices = [
 					{
-							name: i18next.t('command.mod.case.autocomplete.show_history', {
-								lng: locale,
-								user: target.tag,
-							})!,
-							value: `history${OP_DELIMITER}${target.id}`,
+						name: i18next.t('command.mod.case.autocomplete.show_history', {
+							lng: locale,
+							user: target.tag,
+						})!,
+						value: `history${OP_DELIMITER}${target.id}`,
 					},
 					...choices,
 				];
 				if (choices.length > AUTOCOMPLETE_CHOICES_MAX) {
 					choices.length = AUTOCOMPLETE_CHOICES_MAX;
-					}
+				}
 			}
 
 			await interaction.respond(choices.slice(0, 25));


### PR DESCRIPTION
- Prepend rather than append
- Only add to unique map, if the entry does not exist yet, ensuring that the newer tags are used
- remove obsolete try/catch back from attempts at user validation (cannot apply, 30s global cooldown is too much for the rapid 3s autocomplete response time)