### PR TITLE
fix(antispam): only consider blocked, not flagged automod messages

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -23,3 +23,4 @@ export const EMBED_FIELD_NAME_LIMIT = 256;
 export const EMBED_FIELD_VALUE_LIMIT = 1024;
 export const SNOWFLAKE_MIN_LENGTH = 17;
 export const AUTOCOMPLETE_CHOICES_MAX = 25;
+export const AUTOMOD_FLAG_INDICATOR_FIELD_NAME = 'flagged_message_id';

--- a/src/functions/anti-spam/considerableText.ts
+++ b/src/functions/anti-spam/considerableText.ts
@@ -1,0 +1,25 @@
+import type { Message } from 'discord.js';
+import { AUTOMOD_FLAG_INDICATOR_FIELD_NAME } from '../../Constants.js';
+
+export function considerableText(message: Message) {
+	if (message.author.bot || !message.inGuild()) {
+		return null;
+	}
+
+	// @ts-expect-error Automod message, not yet in types (no overlap)
+	if (message.type === 24) {
+		const logEmbed = message.embeds[0]!;
+		const isFlagged = logEmbed.fields?.some((field) => field.name === AUTOMOD_FLAG_INDICATOR_FIELD_NAME);
+		if (isFlagged) {
+			return null;
+		}
+
+		return logEmbed.description;
+	}
+
+	if (!message.content.length) {
+		return null;
+	}
+
+	return message.content;
+}


### PR DESCRIPTION
- Refactor content retrieval into own util function
- Automod: only consider blocked, not flagged messages, prevent double-counting for anti-spam and -scam measures.
- fixes #1059