### PR TITLE
fix(case): truncate choices and embeds

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -22,5 +22,6 @@ export const EMBED_FIELD_LIMIT = 25;
 export const EMBED_FIELD_NAME_LIMIT = 256;
 export const EMBED_FIELD_VALUE_LIMIT = 1024;
 export const SNOWFLAKE_MIN_LENGTH = 17;
-export const AUTOCOMPLETE_CHOICES_MAX = 25;
 export const AUTOMOD_FLAG_INDICATOR_FIELD_NAME = 'flagged_message_id';
+export const AUTOCOMPLETE_CHOICE_LIMIT = 25;
+export const AUTOCOMPLETE_CHOICE_NAME_LENGTH_LIMIT = 100;


### PR DESCRIPTION
- Autocomplete choices have a max name length of 100
- If long reasons were included in the looked up cases, the command would fail because the max length was exceeded
- Truncate case choice values with the ellipsis util function
- Rename old constant for consistency
- Truncate embeds before sending