### PR TITLE
fix(antiraid): consider guild specific member avatar in avatar filter

### DIFF
--- a/packages/yuudachi/src/functions/anti-raid/filters.ts
+++ b/packages/yuudachi/src/functions/anti-raid/filters.ts
@@ -70,7 +70,7 @@ export function avatarFilter(member: GuildMember, avatar?: string | null) {
 		return !member.avatar && !member.user.avatar;
 	}
 
-	return member.user.avatar === avatar || member.avatar === avatar;
+	return member.avatar === avatar || member.user.avatar === avatar;
 }
 
 /**

--- a/packages/yuudachi/src/functions/anti-raid/filters.ts
+++ b/packages/yuudachi/src/functions/anti-raid/filters.ts
@@ -67,10 +67,10 @@ export function avatarFilter(member: GuildMember, avatar?: string | null) {
 	}
 
 	if (avatar.toLowerCase() === 'none') {
-		return !Boolean(member.user.avatar);
+		return !member.avatar && !member.user.avatar;
 	}
 
-	return member.user.avatar === avatar;
+	return member.user.avatar === avatar || member.avatar === avatar;
 }
 
 /**


### PR DESCRIPTION
The command option summary `• Avatar hash (user or member) matching: ` suggests that member avatars are considered, which they weren't so far. This PR changes that.