### PR TITLE
feat(commands): message clear command

### DIFF
--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -2,8 +2,10 @@
 	"common": {
 		"errors": {
 			"no_mod_log_channel": "No mod log channel has been initialized yet.",
-			"no_anti_raid_archive_channel": "No anti-raid archive channel has been initialized yet."
-		}
+			"no_anti_raid_archive_channel": "No anti-raid archive channel has been initialized yet.",
+			"no_content": "<No message content>"
+		},
+		"moderator": "Moderator"
 	},
 	"command": {
 		"common": {
@@ -292,6 +294,7 @@
 				},
 				"pending_one": "You are about to clear {{count}} message by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}. Are you sure?",
 				"pending_other": "You are about to clear {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}. Are you sure?",
+				"message_too_old": "Note: You can only clear messages that are up to 12 hours old. The oldest message that will be cleared is shown below.",
 				"success_one": "Successfully cleared {{count}} message by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}",
 				"success_other": "Successfully cleared {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}.",
 				"authors_one": "{{count}} author",
@@ -405,6 +408,7 @@
 			},
 			"message_bulk_deleted": {
 				"title": "Message deleted bulk",
+				"multiple_authors": "Multiple authors",
 				"description": "• Channel: {{- channel}}\n• Logs: See attachment file for full logs (possibly above this embed)",
 				"attachment": "↳ Attachment: {{- url}}",
 				"sticker": "↳ Sticker: {{- name}}",
@@ -435,7 +439,7 @@
 				"messages_other": "• Messages: {{count}}",
 				"authors_one": "• Author: {{count}}",
 				"authors_other": "• Authors: {{count}}",
-				"time": "Timespan: {{time}}"
+				"time": "• Timespan: {{time}}"
 			}
 		},
 		"general_log": {

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -290,15 +290,15 @@
 					"no_message": "Could not find message {{message_id}} in channel {{- channel}}",
 					"no_results": "Could not find messages in the provided range that are younger than 12 hours."
 				},
-				"pending": "You are about to clear {{count}} message by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}. Are you sure?",
-				"pending_plural": "You are about to clear {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}. Are you sure?",
-				"success": "Successfully cleared {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}",
-				"success_plural": "Successfully cleared {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}.",
-				"authors": "{{count}} author",
-				"authors_plural": "{{count}} authors",
+				"pending_one": "You are about to clear {{count}} message by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}. Are you sure?",
+				"pending_other": "You are about to clear {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}. Are you sure?",
+				"success_one": "Successfully cleared {{count}} message by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}",
+				"success_other": "Successfully cleared {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}.",
+				"authors_one": "{{count}} author",
+				"authors_other": "{{count}} authors",
 				"buttons": {
-					"execute": "Clear {{count}} message",
-					"execute_plural": "Clear {{count}} messages"
+					"execute_one": "Clear {{count}} message",
+					"execute_other": "Clear {{count}} messages"
 				},
 				"cancel": "Cancelled clearing messages."
 			}

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -13,7 +13,8 @@
 				"duration_format": "Wrong duration format.",
 				"use_autocomplete": "Could not resolve the provided option. Make sure to select an autocomplete option.",
 				"target_not_found": "The given member is not in this guild.",
-				"timed_out": "Action timer ran out."
+				"timed_out": "Action timer ran out.",
+				"not_message_id": "Provided value `{{- val}}` for argument `{{- arg}}` is not a valid message id."
 			},
 			"buttons": {
 				"cancel": "Cancel"
@@ -283,6 +284,23 @@
 			},
 			"duration": {
 				"success": "Successfully set duration for case {{- case}}"
+			},
+			"clear": {
+				"errors": {
+					"no_message": "Could not find message {{message_id}} in channel {{- channel}}",
+					"no_results": "Could not find messages in the provided range that are younger than 12 hours."
+				},
+				"pending": "You are about to clear {{count}} message by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}. Are you sure?",
+				"pending_plural": "You are about to clear {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}. Are you sure?",
+				"success": "Successfully cleared {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}",
+				"success_plural": "Successfully cleared {{count}} messages by $t(command.mod.clear.authors, {\"count\": {{author_count}}}) sent in {{time}}.",
+				"authors": "{{count}} author",
+				"authors_plural": "{{count}} authors",
+				"buttons": {
+					"execute": "Clear {{count}} message",
+					"execute_plural": "Clear {{count}} messages"
+				},
+				"cancel": "Cancelled clearing messages."
 			}
 		},
 		"utility": {

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -14,7 +14,7 @@
 				"use_autocomplete": "Could not resolve the provided option. Make sure to select an autocomplete option.",
 				"target_not_found": "The given member is not in this guild.",
 				"timed_out": "Action timer ran out.",
-				"not_message_id": "Provided value `{{- val}}` for argument `{{- arg}}` is not a valid message id."
+				"not_message_id": "Provided value `{{val}}` for argument `{{arg}}` is not a valid message id."
 			},
 			"buttons": {
 				"cancel": "Cancel"
@@ -428,6 +428,14 @@
 				"channel": "• Thread: {{- name}} {{channel_id}}",
 				"starter": "• Starter message: {{message_id}}",
 				"jump_to": "• [Jump to starter message]({{- link}})"
+			},
+			"messages_cleared": {
+				"title": "Messages cleared",
+				"messages_one": "• Message: {{count}}",
+				"messages_other": "• Messages: {{count}}",
+				"authors_one": "• Author: {{count}}",
+				"authors_other": "• Authors: {{count}}",
+				"time": "Timespan: {{time}}"
 			}
 		},
 		"general_log": {

--- a/packages/yuudachi/src/Constants.ts
+++ b/packages/yuudachi/src/Constants.ts
@@ -16,6 +16,7 @@ export const ANTI_RAID_NUKE_AVATAR_THRESHOLD = 5;
 export const ANTI_RAID_NUKE_PROGRESS_SPLIT = 50;
 
 export const DATE_FORMAT_LOGFILE = 'YYYY-MM-DD_HH-mm-ss';
+export const DATE_FORMAT_WITH_SECONDS = 'YYYY/MM/DD HH:mm:ss';
 
 export const EMBED_TITLE_LIMIT = 256;
 export const EMBED_DESCRIPTION_LIMIT = 4096;

--- a/packages/yuudachi/src/commands/moderation/clear.ts
+++ b/packages/yuudachi/src/commands/moderation/clear.ts
@@ -21,9 +21,9 @@ export default class implements Command {
 		if (!/^\d{17,20}$/.test(args.last_message)) {
 			throw new Error(
 				i18next.t('command.common.errors.not_message_id', {
-					lng: locale,
 					val: args.last_message,
 					arg: 'from',
+					lng: locale,
 				}),
 			);
 		}
@@ -31,9 +31,9 @@ export default class implements Command {
 		if (args.first_message && !/^\d{17,20}$/.test(args.first_message)) {
 			throw new Error(
 				i18next.t('command.common.errors.not_message_id', {
-					lng: locale,
 					val: args.first_message,
 					arg: 'to',
+					lng: locale,
 				}),
 			);
 		}
@@ -41,10 +41,10 @@ export default class implements Command {
 		const firstMessage = await interaction.channel!.messages.fetch(args.last_message).catch(() => {
 			throw new Error(
 				i18next.t('command.mod.clear.errors.no_message', {
-					lng: locale,
 					message_id: args.last_message,
 					// eslint-disable-next-line @typescript-eslint/no-base-to-string
 					channel: interaction.channel!.toString(),
+					lng: locale,
 				}),
 			);
 		});
@@ -52,10 +52,10 @@ export default class implements Command {
 			? await interaction.channel!.messages.fetch(args.first_message).catch(() => {
 					throw new Error(
 						i18next.t('command.mod.clear.errors.no_message', {
-							lng: locale,
 							message_id: args.first_message,
 							// eslint-disable-next-line @typescript-eslint/no-base-to-string
 							channel: interaction.channel!.toString(),
+							lng: locale,
 						}),
 					);
 			  })

--- a/packages/yuudachi/src/commands/moderation/clear.ts
+++ b/packages/yuudachi/src/commands/moderation/clear.ts
@@ -78,9 +78,10 @@ export default class implements Command {
 
 		const clearKey = nanoid();
 		const cancelKey = nanoid();
+
 		const clearButton = createButton({
 			customId: clearKey,
-			label: i18next.t('command.mod.clear.buttons.execute', { lng: locale, count: messages.size }),
+			label: i18next.t('command.mod.clear.buttons.execute', { count: messages.size, lng: locale }),
 			style: ButtonStyle.Danger,
 		});
 		const cancelButton = createButton({

--- a/packages/yuudachi/src/commands/moderation/clear.ts
+++ b/packages/yuudachi/src/commands/moderation/clear.ts
@@ -1,0 +1,154 @@
+import { ms } from '@naval-base/ms';
+import { ButtonStyle, CommandInteraction, ComponentType } from 'discord.js';
+import i18next from 'i18next';
+import { nanoid } from 'nanoid';
+import type { Command } from '../../Command.js';
+import { fetchMessages, pruneMessages } from '../../functions/pruning/pruneMessages.js';
+import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
+import type { ClearCommand } from '../../interactions/moderation/clear.js';
+import { logger } from '../../logger.js';
+import { createButton } from '../../util/button.js';
+import { createMessageActionRow } from '../../util/messageActionRow.js';
+
+export default class implements Command {
+	public async execute(
+		interaction: CommandInteraction<'cached'>,
+		args: ArgumentsOf<typeof ClearCommand>,
+		locale: string,
+	): Promise<void> {
+		const reply = await interaction.deferReply({ ephemeral: true, fetchReply: true });
+
+		if (!/^\d{17,20}$/.test(args.last_message)) {
+			throw new Error(
+				i18next.t('command.common.errors.not_message_id', {
+					lng: locale,
+					val: args.last_message,
+					arg: 'from',
+				}),
+			);
+		}
+
+		if (args.first_message && !/^\d{17,20}$/.test(args.first_message)) {
+			throw new Error(
+				i18next.t('command.common.errors.not_message_id', {
+					lng: locale,
+					val: args.first_message,
+					arg: 'to',
+				}),
+			);
+		}
+
+		const firstMessage = await interaction.channel!.messages.fetch(args.last_message).catch(() => {
+			throw new Error(
+				i18next.t('command.mod.clear.errors.no_message', {
+					lng: locale,
+					message_id: args.last_message,
+					// eslint-disable-next-line @typescript-eslint/no-base-to-string
+					channel: interaction.channel!.toString(),
+				}),
+			);
+		});
+		const lastMessage = args.first_message
+			? await interaction.channel!.messages.fetch(args.first_message).catch(() => {
+					throw new Error(
+						i18next.t('command.mod.clear.errors.no_message', {
+							lng: locale,
+							message_id: args.first_message,
+							// eslint-disable-next-line @typescript-eslint/no-base-to-string
+							channel: interaction.channel!.toString(),
+						}),
+					);
+			  })
+			: undefined;
+
+		const messages = await fetchMessages(interaction.channel!, firstMessage, lastMessage);
+
+		if (messages.size < 1) {
+			throw new Error(
+				i18next.t('command.mod.clear.errors.no_results', {
+					lng: locale,
+				}),
+			);
+		}
+
+		const uniqueAuthors = new Set(messages.map((m) => m.author.id));
+		const latest = messages.first()!;
+		const earliest = messages.last()!;
+		const delta = latest.createdTimestamp - earliest.createdTimestamp;
+
+		const clearKey = nanoid();
+		const cancelKey = nanoid();
+		const clearButton = createButton({
+			customId: clearKey,
+			label: i18next.t('command.mod.clear.buttons.execute', { lng: locale, count: messages.size }),
+			style: ButtonStyle.Danger,
+		});
+		const cancelButton = createButton({
+			customId: cancelKey,
+			label: i18next.t('command.common.buttons.cancel', { lng: locale }),
+			style: ButtonStyle.Secondary,
+		});
+
+		await interaction.editReply({
+			content: i18next.t('command.mod.clear.pending', {
+				count: messages.size,
+				author_count: uniqueAuthors.size,
+				time: ms(delta, true),
+				lng: locale,
+			}),
+			components: [createMessageActionRow([cancelButton, clearButton])],
+		});
+
+		const collectedInteraction = await reply
+			.awaitMessageComponent({
+				filter: (collected) => collected.user.id === interaction.user.id,
+				componentType: ComponentType.Button,
+				time: 15000,
+			})
+			.catch(async () => {
+				try {
+					await interaction.editReply({
+						content: i18next.t('command.common.errors.timed_out', { lng: locale }),
+						components: [],
+					});
+				} catch (e) {
+					const error = e as Error;
+					logger.error(error, error.message);
+				}
+				return undefined;
+			});
+
+		if (collectedInteraction?.customId === cancelKey) {
+			await collectedInteraction.update({
+				content: i18next.t('command.mod.clear.cancel', {
+					lng: locale,
+				}),
+				components: [],
+			});
+		} else if (collectedInteraction?.customId === clearKey) {
+			logger.info(`Pruning messages`, {
+				amount: messages.size,
+				timespan: ms(delta, true),
+				unique_authors: uniqueAuthors.size,
+			});
+
+			await collectedInteraction.deferUpdate();
+			const prunedMessages = await pruneMessages(interaction.channel!, messages);
+
+			const prunedUniqueAuthors = new Set(messages.map((m) => m.author.id));
+			const prunedLatest = messages.first()!;
+			const prunedEarliest = messages.last()!;
+			const prunedDelta = prunedLatest.createdTimestamp - prunedEarliest.createdTimestamp;
+
+			await collectedInteraction.editReply({
+				content: i18next.t('command.mod.clear.success', {
+					count: prunedMessages.size,
+					author_count: prunedUniqueAuthors.size,
+					time: ms(prunedDelta, true),
+					lng: locale,
+				}),
+				components: [],
+			});
+		}
+	}
+}

--- a/packages/yuudachi/src/commands/moderation/duration.ts
+++ b/packages/yuudachi/src/commands/moderation/duration.ts
@@ -1,5 +1,5 @@
 import { ms } from '@naval-base/ms';
-import { type CommandInteraction, hyperlink } from 'discord.js';
+import { type CommandInteraction, hyperlink, messageLink } from 'discord.js';
 import i18next from 'i18next';
 import type { Command } from '../../Command.js';
 import { getCase } from '../../functions/cases/getCase.js';
@@ -9,7 +9,6 @@ import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
 import type { DurationCommand } from '../../interactions/index.js';
-import { generateMessageLink } from '../../util/generateMessageLink.js';
 
 export default class implements Command {
 	public async execute(
@@ -51,7 +50,7 @@ export default class implements Command {
 			content: i18next.t('command.mod.duration.success', {
 				case: hyperlink(
 					`#${originalCase.caseId}`,
-					generateMessageLink(interaction.guildId, modLogChannel.id, originalCase.logMessageId!),
+					messageLink(interaction.guildId, modLogChannel.id, originalCase.logMessageId!),
 				),
 				lng: locale,
 			}),

--- a/packages/yuudachi/src/commands/moderation/reason.ts
+++ b/packages/yuudachi/src/commands/moderation/reason.ts
@@ -1,4 +1,4 @@
-import { type CommandInteraction, ComponentType, ButtonStyle, hyperlink } from 'discord.js';
+import { type CommandInteraction, ComponentType, ButtonStyle, hyperlink, messageLink } from 'discord.js';
 import i18next from 'i18next';
 import { nanoid } from 'nanoid';
 import type { Command } from '../../Command.js';
@@ -13,7 +13,6 @@ import type { ReasonCommand } from '../../interactions/index.js';
 import { logger } from '../../logger.js';
 import { createButton } from '../../util/button.js';
 import { truncate } from '../../util/embed.js';
-import { generateMessageLink } from '../../util/generateMessageLink.js';
 import { createMessageActionRow } from '../../util/messageActionRow.js';
 
 export default class implements Command {
@@ -86,11 +85,11 @@ export default class implements Command {
 				content: i18next.t('command.mod.reason.pending_multiple', {
 					lower_case: hyperlink(
 						`#${lower}`,
-						generateMessageLink(interaction.guildId, modLogChannel.id, originalCaseLower.logMessageId!),
+						messageLink(modLogChannel.id, originalCaseLower.logMessageId!, interaction.guildId),
 					),
 					upper_case: hyperlink(
 						`#${upper}`,
-						generateMessageLink(interaction.guildId, modLogChannel.id, originalCaseUpper.logMessageId!),
+						messageLink(modLogChannel.id, originalCaseUpper.logMessageId!, interaction.guildId),
 					),
 					count: upper - lower + 1,
 					lng: locale,
@@ -169,11 +168,11 @@ export default class implements Command {
 			? i18next.t('command.mod.reason.success_multiple', {
 					lower_case: hyperlink(
 						`#${lower}`,
-						generateMessageLink(interaction.guildId, modLogChannel.id, originalCaseLower.logMessageId!),
+						messageLink(modLogChannel.id, originalCaseLower.logMessageId!, interaction.guildId),
 					),
 					upper_case: hyperlink(
 						`#${upper}`,
-						generateMessageLink(interaction.guildId, modLogChannel.id, originalCaseUpper!.logMessageId!),
+						messageLink(modLogChannel.id, originalCaseUpper!.logMessageId!, interaction.guildId),
 					),
 					amount: success.length,
 					count: upper - lower + 1,
@@ -182,7 +181,7 @@ export default class implements Command {
 			: i18next.t('command.mod.reason.success', {
 					case: hyperlink(
 						`#${lower}`,
-						generateMessageLink(interaction.guildId, modLogChannel.id, originalCaseLower.logMessageId!),
+						messageLink(modLogChannel.id, originalCaseLower.logMessageId!, interaction.guildId),
 					),
 					lng: locale,
 			  });

--- a/packages/yuudachi/src/commands/moderation/reference.ts
+++ b/packages/yuudachi/src/commands/moderation/reference.ts
@@ -1,4 +1,4 @@
-import { type CommandInteraction, hyperlink } from 'discord.js';
+import { type CommandInteraction, hyperlink, messageLink } from 'discord.js';
 import i18next from 'i18next';
 import type { Command } from '../../Command.js';
 import { getCase } from '../../functions/cases/getCase.js';
@@ -8,7 +8,6 @@ import { checkLogChannel } from '../../functions/settings/checkLogChannel.js';
 import { getGuildSetting, SettingsKeys } from '../../functions/settings/getGuildSetting.js';
 import type { ArgumentsOf } from '../../interactions/ArgumentsOf.js';
 import type { ReferenceCommand } from '../../interactions/index.js';
-import { generateMessageLink } from '../../util/generateMessageLink.js';
 
 export default class implements Command {
 	public async execute(
@@ -50,11 +49,11 @@ export default class implements Command {
 			content: i18next.t('command.mod.reference.success', {
 				case: hyperlink(
 					`#${originalCase.caseId}`,
-					generateMessageLink(interaction.guildId, modLogChannel.id, originalCase.logMessageId!),
+					messageLink(modLogChannel.id, originalCase.logMessageId!, interaction.guildId),
 				),
 				ref: hyperlink(
 					`#${referenceCase.caseId}`,
-					generateMessageLink(interaction.guildId, modLogChannel.id, referenceCase.logMessageId!),
+					messageLink(modLogChannel.id, referenceCase.logMessageId!, interaction.guildId),
 				),
 				lng: locale,
 			}),

--- a/packages/yuudachi/src/deploy.ts
+++ b/packages/yuudachi/src/deploy.ts
@@ -18,6 +18,7 @@ import {
 	UnbanCommand,
 	WarnCommand,
 	TimeoutCommand,
+	ClearCommand,
 
 	// Utility
 	PingCommand,
@@ -52,6 +53,7 @@ try {
 			WarnCommand,
 			LockdownCommand,
 			TimeoutCommand,
+			ClearCommand,
 
 			// Utility
 			PingCommand,

--- a/packages/yuudachi/src/functions/logging/formatMessagesToAttachment.ts
+++ b/packages/yuudachi/src/functions/logging/formatMessagesToAttachment.ts
@@ -1,0 +1,67 @@
+import dayjs from 'dayjs';
+import { Collection, Message, messageLink, MessageType, Snowflake } from 'discord.js';
+import i18next from 'i18next';
+import { DATE_FORMAT_WITH_SECONDS } from '../../Constants.js';
+
+export function formatMessagesToAttachment(messages: Collection<Snowflake, Message>, locale: string) {
+	return messages
+		.map((message) => {
+			const outParts = [
+				`[${dayjs(message.createdTimestamp).utc().format(DATE_FORMAT_WITH_SECONDS)} (UTC)] ${message.author.tag} (${
+					message.author.id
+				}): ${message.cleanContent ? message.cleanContent.replace(/\n/g, '\n') : ''}`,
+			];
+
+			if (message.attachments.size) {
+				outParts.push(
+					message.attachments
+						.map((attachment) =>
+							i18next.t('log.guild_log.message_bulk_deleted.attachment', {
+								url: attachment.proxyURL,
+								lng: locale,
+							}),
+						)
+						.join('\n'),
+				);
+			}
+
+			if (message.stickers.size) {
+				outParts.push(
+					message.stickers
+						.map((sticker) =>
+							i18next.t('log.guild_log.message_bulk_deleted.sticker', {
+								name: sticker.name,
+								lng: locale,
+							}),
+						)
+						.join('\n'),
+				);
+			}
+
+			if (message.type === MessageType.Reply && message.reference && message.mentions.repliedUser) {
+				const { channelId, messageId, guildId } = message.reference;
+				const replyURL = messageLink(channelId, messageId!, guildId!);
+
+				outParts.push(
+					message.mentions.users.has(message.mentions.repliedUser.id)
+						? i18next.t('log.guild_log.message_bulk_deleted.reply_to_mentions', {
+								message_id: messageId,
+								message_url: replyURL,
+								user_tag: message.mentions.repliedUser.tag,
+								user_id: message.mentions.repliedUser.id,
+								lng: locale,
+						  })
+						: i18next.t('log.guild_log.message_bulk_deleted.reply_to', {
+								message_id: messageId,
+								message_url: replyURL,
+								user_tag: message.mentions.repliedUser.tag,
+								user_id: message.mentions.repliedUser.id,
+								lng: locale,
+						  }),
+				);
+			}
+
+			return outParts.join('\n');
+		})
+		.join('\n');
+}

--- a/packages/yuudachi/src/functions/logging/generateCaseLog.ts
+++ b/packages/yuudachi/src/functions/logging/generateCaseLog.ts
@@ -1,10 +1,9 @@
-import { Client, type Snowflake, hyperlink, time, TimestampStyles } from 'discord.js';
+import { Client, type Snowflake, hyperlink, time, TimestampStyles, messageLink } from 'discord.js';
 import i18next from 'i18next';
 import type { Sql } from 'postgres';
 import { container } from 'tsyringe';
 import { logger } from '../../logger.js';
 import { kSQL } from '../../tokens.js';
-import { generateMessageLink } from '../../util/generateMessageLink.js';
 import { type Case, CaseAction } from '../cases/createCase.js';
 
 export async function generateCaseLog(case_: Case, logChannelId: Snowflake, locale: string) {
@@ -53,7 +52,7 @@ export async function generateCaseLog(case_: Case, logChannelId: Snowflake, loca
 			msg += i18next.t('log.mod_log.case_log.context', {
 				link: hyperlink(
 					i18next.t('log.mod_log.case_log.context_sub', { lng: locale }),
-					generateMessageLink(case_.guildId, contextMessage!.channel_id!, case_.contextMessageId),
+					messageLink(contextMessage!.channel_id!, case_.contextMessageId, case_.guildId),
 				),
 				lng: locale,
 			});
@@ -75,10 +74,7 @@ export async function generateCaseLog(case_: Case, logChannelId: Snowflake, loca
 
 		if (Reflect.has(reference ?? {}, 'log_message_id')) {
 			msg += i18next.t('log.mod_log.case_log.reference', {
-				ref: hyperlink(
-					`#${case_.referenceId}`,
-					generateMessageLink(case_.guildId, logChannelId, reference!.log_message_id!),
-				),
+				ref: hyperlink(`#${case_.referenceId}`, messageLink(logChannelId, reference!.log_message_id!, case_.guildId)),
 				lng: locale,
 			});
 		}

--- a/packages/yuudachi/src/functions/pruning/pruneMessages.ts
+++ b/packages/yuudachi/src/functions/pruning/pruneMessages.ts
@@ -37,12 +37,6 @@ export async function fetchMessages(channel: TextBasedChannel, from: Message, to
 	while (
 		pivot ? oldest.createdTimestamp < pivot.createdTimestamp && pivot.createdTimestamp > earliestPossiblePrune : true
 	) {
-		console.log('fetching more', {
-			pivot: pivot?.createdTimestamp,
-			oldest: oldest.createdTimestamp,
-			res_size: res.size,
-		});
-
 		const messages = await channel.messages.fetch({
 			limit: 100,
 			before: pivot?.id,
@@ -58,7 +52,6 @@ export async function fetchMessages(channel: TextBasedChannel, from: Message, to
 		pivot = messages.last();
 	}
 
-	console.log('res size: ', res.size);
 	return res;
 }
 
@@ -82,8 +75,6 @@ export function chunkMessages(messages: Collection<Snowflake, Message>) {
 }
 
 export async function pruneMessages(channel: GuildTextBasedChannel, messages: Collection<Snowflake, Message>) {
-	console.log(messages.map((m) => `${m.author.tag}: ${m.content}`).join('\n'));
-
 	const res = new Collection<Snowflake, Message>();
 	for (const chunk of chunkMessages(messages)) {
 		const deleted = await channel.bulkDelete(chunk, true);

--- a/packages/yuudachi/src/functions/pruning/pruneMessages.ts
+++ b/packages/yuudachi/src/functions/pruning/pruneMessages.ts
@@ -5,7 +5,7 @@ interface MessageOrder {
 	oldest: Message;
 }
 
-function orderMessages(first: Message, second?: Message): MessageOrder {
+export function orderMessages(first: Message, second?: Message): MessageOrder {
 	if (first.id === second?.id || !second) {
 		return {
 			newest: undefined,
@@ -24,7 +24,6 @@ function orderMessages(first: Message, second?: Message): MessageOrder {
 
 export async function fetchMessages(channel: TextBasedChannel, from: Message, to?: Message) {
 	const { newest, oldest } = orderMessages(from, to);
-
 	const res = new Collection<Snowflake, Message>();
 
 	if (newest) {
@@ -75,11 +74,11 @@ export function chunkMessages(messages: Collection<Snowflake, Message>) {
 }
 
 export async function pruneMessages(channel: GuildTextBasedChannel, messages: Collection<Snowflake, Message>) {
-	const res = new Collection<Snowflake, Message>();
+	const deletedMessages = new Set<Snowflake>();
 	for (const chunk of chunkMessages(messages)) {
 		const deleted = await channel.bulkDelete(chunk, true);
-		res.concat(deleted);
+		deleted.forEach((_, id) => deletedMessages.add(id));
 	}
 
-	return res;
+	return messages.filter((message) => deletedMessages.has(message.id));
 }

--- a/packages/yuudachi/src/functions/pruning/pruneMessages.ts
+++ b/packages/yuudachi/src/functions/pruning/pruneMessages.ts
@@ -1,0 +1,94 @@
+import { Collection, GuildTextBasedChannel, Message, Snowflake, SnowflakeUtil, TextBasedChannel } from 'discord.js';
+
+interface MessageOrder {
+	newest?: Message;
+	oldest: Message;
+}
+
+function orderMessages(first: Message, second?: Message): MessageOrder {
+	if (first.id === second?.id || !second) {
+		return {
+			newest: undefined,
+			oldest: first,
+		};
+	}
+
+	const firstTimestamp = SnowflakeUtil.timestampFrom(first.id);
+	const secondTimestamp = SnowflakeUtil.timestampFrom(second.id);
+
+	return {
+		newest: firstTimestamp > secondTimestamp ? first : second,
+		oldest: firstTimestamp < secondTimestamp ? first : second,
+	};
+}
+
+export async function fetchMessages(channel: TextBasedChannel, from: Message, to?: Message) {
+	const { newest, oldest } = orderMessages(from, to);
+
+	const res = new Collection<Snowflake, Message>();
+
+	if (newest) {
+		res.set(newest.id, newest);
+	}
+
+	let pivot = newest;
+
+	const earliestPossiblePrune = Date.now() - 12 * 60 * 60 * 1000;
+	while (
+		pivot ? oldest.createdTimestamp < pivot.createdTimestamp && pivot.createdTimestamp > earliestPossiblePrune : true
+	) {
+		console.log('fetching more', {
+			pivot: pivot?.createdTimestamp,
+			oldest: oldest.createdTimestamp,
+			res_size: res.size,
+		});
+
+		const messages = await channel.messages.fetch({
+			limit: 100,
+			before: pivot?.id,
+			cache: false,
+		});
+		for (const message of messages.values()) {
+			if (message.createdTimestamp >= oldest.createdTimestamp && message.createdTimestamp >= earliestPossiblePrune) {
+				res.set(message.id, message);
+			} else {
+				break;
+			}
+		}
+		pivot = messages.last();
+	}
+
+	console.log('res size: ', res.size);
+	return res;
+}
+
+export function chunkMessages(messages: Collection<Snowflake, Message>) {
+	const res = [];
+	const chunk = [];
+
+	for (const message of messages.values()) {
+		if (chunk.length === 100) {
+			res.push([...chunk]);
+			chunk.length = 0;
+		}
+		chunk.push(message);
+	}
+
+	if (chunk.length) {
+		res.push([...chunk]);
+	}
+
+	return res;
+}
+
+export async function pruneMessages(channel: GuildTextBasedChannel, messages: Collection<Snowflake, Message>) {
+	console.log(messages.map((m) => `${m.author.tag}: ${m.content}`).join('\n'));
+
+	const res = new Collection<Snowflake, Message>();
+	for (const chunk of chunkMessages(messages)) {
+		const deleted = await channel.bulkDelete(chunk, true);
+		res.concat(deleted);
+	}
+
+	return res;
+}

--- a/packages/yuudachi/src/interactions/index.ts
+++ b/packages/yuudachi/src/interactions/index.ts
@@ -12,6 +12,7 @@ export * from './moderation/softban.js';
 export * from './moderation/unban.js';
 export * from './moderation/warn.js';
 export * from './moderation/timeout.js';
+export * from './moderation/clear.js';
 export * from './utility/ping.js';
 export * from './utility/checkScam.js';
 export * from './utility/refreshScams.js';

--- a/packages/yuudachi/src/interactions/moderation/clear.ts
+++ b/packages/yuudachi/src/interactions/moderation/clear.ts
@@ -1,0 +1,20 @@
+import { ApplicationCommandOptionType } from 'discord-api-types/v10';
+
+export const ClearCommand = {
+	name: 'clear',
+	description: 'Clear messages',
+	options: [
+		{
+			name: 'last_message',
+			description: 'The last message to clear',
+			type: ApplicationCommandOptionType.String,
+			required: true,
+		},
+		{
+			name: 'first_message',
+			description: 'The first message to clear',
+			type: ApplicationCommandOptionType.String,
+		},
+	],
+	default_member_permissions: '0',
+} as const;

--- a/packages/yuudachi/src/util/generateHistory.ts
+++ b/packages/yuudachi/src/util/generateHistory.ts
@@ -11,13 +11,13 @@ import {
 	inlineCode,
 	time,
 	TimestampStyles,
+	messageLink,
 } from 'discord.js';
 import i18next from 'i18next';
 import type { Sql } from 'postgres';
 import { container } from 'tsyringe';
 import { ACTION_KEYS } from './actionKeys.js';
 import { addFields, truncateEmbed } from './embed.js';
-import { generateMessageLink } from './generateMessageLink.js';
 import type { RawCase } from '../functions/cases/transformCase.js';
 import { getGuildSetting, SettingsKeys } from '../functions/settings/getGuildSetting.js';
 import { kSQL } from '../tokens.js';
@@ -133,7 +133,7 @@ export async function generateHistory(
 		const dateFormatted = time(dayjs(c.created_at).unix(), TimestampStyles.ShortDate);
 		const caseString = `${dateFormatted} ${inlineCode(`${ACTION_KEYS[c.action]!.toUpperCase()}`)} ${
 			c.log_message_id
-				? hyperlink(`#${c.case_id}`, generateMessageLink(c.guild_id, modLogChannelId, c.log_message_id))
+				? hyperlink(`#${c.case_id}`, messageLink(modLogChannelId, c.log_message_id), c.guild_id)
 				: `#${c.case_id}`
 		} ${c.reason?.replace(/\*/g, '') ?? ''}`;
 

--- a/packages/yuudachi/src/util/generateMessageLink.ts
+++ b/packages/yuudachi/src/util/generateMessageLink.ts
@@ -1,5 +1,0 @@
-import type { Snowflake } from 'discord.js';
-
-export function generateMessageLink(guildId: Snowflake, channelId: Snowflake, messageId: Snowflake) {
-	return `https://discord.com/channels/${guildId}/${channelId}/${messageId}`;
-}


### PR DESCRIPTION
Introduce a command to clear messages in a provided range
- 1 message: clear up to and include this message
- 2 messages: clear in range between and including both messages
- 12h in the past max to safeguard (accidental) abuse
- Verbose confirmation flow

![image](https://user-images.githubusercontent.com/26532370/182032668-04b301a6-3ca4-459c-85c9-3beeb7bb27ae.png)


> **Warning**
> bulk delete logs can no longer assume a single author for all messages on bulk delete and need to be refactored to account for that

> **Note**
> Waiting for https://github.com/Naval-Base/yuudachi/pull/1080 to be merged, so this can build on the extended message logs when logging the clear as a separate action in guild logs.
