### PR TITLE
fix: Dynamic import throwing

### DIFF
--- a/packages/yuudachi/src/index.ts
+++ b/packages/yuudachi/src/index.ts
@@ -79,9 +79,8 @@ try {
 			continue;
 		}
 
-		const dynamic = await dynamicImport<new () => Command<CommandPayload>>(
-			() => import(pathToFileURL(dir.fullPath).href),
-		);
+		const dynamic = await dynamicImport<Command<CommandPayload>>(pathToFileURL(dir.fullPath).href);
+
 		const command = container.resolve<Command<CommandPayload>>(dynamic.default);
 		logger.info(
 			{ command: { name: command.name?.join(', ') ?? cmdInfo.name } },
@@ -93,7 +92,7 @@ try {
 	}
 
 	for await (const dir of eventFiles) {
-		const dynamic = await dynamicImport<new () => Event>(() => import(pathToFileURL(dir.fullPath).href));
+		const dynamic = await dynamicImport<Event>(pathToFileURL(dir.fullPath).href);
 		const event_ = container.resolve<Event>(dynamic.default);
 		logger.info({ event: { name: event_.name, event: event_.event } }, `Registering event: ${event_.name}`);
 

--- a/packages/yuudachi/src/util/dynamicImport.ts
+++ b/packages/yuudachi/src/util/dynamicImport.ts
@@ -1,3 +1,5 @@
-export function dynamicImport<T, R = Promise<{ default: T }>>(factory: () => Promise<any>) {
-	return factory as unknown as R;
+import type { InjectionToken } from 'tsyringe';
+
+export function dynamicImport<T, R = Promise<{ default: InjectionToken<T> }>>(path: string) {
+	return import(path) as unknown as R;
 }


### PR DESCRIPTION
```json
{
    "level": 50,
    "time": 1659490614372,
    "pid": 12400,
    "hostname": "LAPTOP-88LFRJR1",
    "name": "dev_logger",
    "err": {
        "type": "Error",
        "message": "Attempted to construct an undefined constructor. Could mean a circular dependency problem. Try using `delay` function.",
        "stack": "Error: Attempted to construct an undefined constructor. Could mean a circular dependency problem. Try using `delay` function.\n    at InternalDependencyContainer.resolve (C:\\Users\\jpedr\\Desktop\\Visual Code\\Node.js\\yuudachi\\node_modules\\tsyringe\\dist\\cjs\\dependency-container.js:118:15)\n    at <anonymous> (C:\\Users\\jpedr\\Desktop\\Visual Code\\Node.js\\yuudachi\\packages\\yuudachi\\src\\index.ts:85:29)"
        },
    "msg": "Attempted to construct an undefined constructor. Could mean a circular dependency problem. Try using `delay` function."
}
```

```ts
await dynamicImport<T>(pathToFileURL(dir.fullPath).href);
```

The `dynamicImport` now takes an path as argument and return an promise of an `import` resolved as `<T, R = Promise<{ default: InjectionToken<T> }>>`