### PR TITLE
fix(anti-raid-nuke): full_match option when not using regex delimiters

### DIFF
--- a/packages/yuudachi/src/util/parseRegex.ts
+++ b/packages/yuudachi/src/util/parseRegex.ts
@@ -17,7 +17,7 @@ export function parseRegex(input?: string | undefined | null, insensitive = true
 			return new RE2(input.replace(regex, fullMatch ? '^$1$' : '$1'), options);
 		}
 
-		return new RE2(input, options);
+		return new RE2(fullMatch ? `^${input}$` : input, options);
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
The full match option also needs to be respected, when net using the regex delimiter format for the pattern option