### PR TITLE
feat(memberlog): show created and joined timestamp

### DIFF
--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -514,8 +514,8 @@
 			}
 		},
 		"member_log": {
-			"description": "• Username: {{- user_mention}} - `{{- user_tag}}` ({{user_id}})\n• Created: {{- created_at}} ({{- created_at_since}})",
-			"joined_at": "\n• Joined: {{- joined_at}} ({{- joined_at_since}})",
+			"description": "• Username: {{- user_mention}} - `{{- user_tag}}` ({{user_id}})\n• Created: {{- created_at}} ({{- created_at_since}}) `{{created_at_timestamp}}`",
+			"joined_at": "\n• Joined: {{- joined_at}} ({{- joined_at_since}}) `{{joined_at_timestamp}}`",
 			"left_at": "\n• Left: {{- left_at}} ({{- left_at_since}})",
 			"footer": {
 				"joined": "User joined",

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -417,7 +417,7 @@
 				},
 				"user_details": {
 					"title": "User details",
-					"description": "• Username: {{- user_mention}} - `{{- user_tag}}` ({{user_id}})\n• Created: {{- created_at}} ({{- created_at_since}})"
+					"description": "• Username: {{- user_mention}} - `{{- user_tag}}` ({{user_id}})\n• Created: {{- created_at}} ({{- created_at_since}}) `{{created_at_timestamp}}`"
 				},
 				"member_details": {
 					"title": "Member details",
@@ -425,7 +425,7 @@
 						"nickname": "• Nickname: `{{- nickname}}`",
 						"roles_one": "• Role ({{count}}): {{- roles}}",
 						"roles_other": "• Roles ({{count}}): {{- roles}}",
-						"joined": "• Joined: {{- joined_at}} ({{- joined_at_since}})"
+						"joined": "• Joined: {{- joined_at}} ({{- joined_at_since}}) `{{joined_at_timestamp}}`"
 					}
 				}
 			},

--- a/packages/yuudachi/src/util/generateHistory.ts
+++ b/packages/yuudachi/src/util/generateHistory.ts
@@ -350,6 +350,7 @@ export function generateUserInfo(target: { member?: GuildMember | undefined; use
 				user_id: target.user.id,
 				created_at: creationFormatted,
 				created_at_since: sinceCreationFormatted,
+				created_at_timestamp: target.user.createdTimestamp,
 				lng: locale,
 			}),
 		},
@@ -385,6 +386,7 @@ export function generateUserInfo(target: { member?: GuildMember | undefined; use
 			i18next.t("log.history.common.member_details.description.joined", {
 				joined_at: joinFormatted,
 				joined_at_since: sinceJoinFormatted,
+				joined_at_timestamp: target.member.joinedTimestamp,
 				lng: locale,
 			}),
 		);

--- a/packages/yuudachi/src/util/generateMemberLog.ts
+++ b/packages/yuudachi/src/util/generateMemberLog.ts
@@ -40,6 +40,7 @@ export function generateMemberLog(member: GuildMember, locale: string, join = tr
 		user_id: member.user.id,
 		created_at: creationFormatted,
 		created_at_since: sinceCreationFormatted,
+		created_at_timestamp: member.user.createdTimestamp,
 		lng: locale,
 	});
 
@@ -50,6 +51,7 @@ export function generateMemberLog(member: GuildMember, locale: string, join = tr
 		description += i18next.t("log.member_log.joined_at", {
 			joined_at: joinFormatted,
 			joined_at_since: sinceJoinFormatted,
+			joined_at_timestamp: member.joinedTimestamp,
 			lng: locale,
 		});
 	}


### PR DESCRIPTION
Add the raw timestamp values for join and creation date in member logs. Useful to better determine anti-raid-nuke arguments.
![image](https://user-images.githubusercontent.com/26532370/189659968-6f9eabf1-1c75-409d-865f-0aae90fe68e4.png)

- [x] Add timestamps to history user info

> **Note**
> Blocked while waiting for https://github.com/Naval-Base/yuudachi/pull/1103 as the user info components are refactored and made consistent