### PR TITLE
chore(scam_domains): Move the `X-Identity` info to its own ENV

### DIFF
--- a/packages/yuudachi/src/functions/anti-scam/refreshScamDomains.ts
+++ b/packages/yuudachi/src/functions/anti-scam/refreshScamDomains.ts
@@ -31,7 +31,7 @@ export function checkResponse(response: Dispatcher.ResponseData) {
 
 export const scamDomainRequestHeaders = {
 	SCAM_DOMAIN_URL: {
-		"X-Identity": "Naval-Base/yuudachi",
+		"X-Identity": process.env.SCAM_DOMAIN_IDENTITY!,
 	},
 	SCAM_DOMAIN_DISCORD_URL: {},
 } as const;
@@ -49,6 +49,11 @@ export async function refreshScamDomains(redis?: Redis | undefined) {
 
 		if (!url) {
 			logger.warn(`Missing env var: ${urlEnvironment}`);
+			continue;
+		}
+
+		if (urlEnvironment === "SCAM_DOMAIN_DISCORD_URL" && !process.env.SCAM_DOMAIN_IDENTITY) {
+			logger.warn(`Missing env var 'SCAM_DOMAIN_IDENTITY' to fetch ${urlEnvironment}`);
 			continue;
 		}
 
@@ -81,7 +86,7 @@ export async function refreshScamDomains(redis?: Redis | undefined) {
 				const lastRefreshTimestamp = Number.parseInt(lastRefresh, 10);
 
 				logger.info({
-					msg: "refreshd scam domains",
+					msg: "refreshed scam domains",
 					envVar: urlEnvironment,
 					redisKey: key,
 					lastRefresh: lastRefreshTimestamp,

--- a/packages/yuudachi/src/index.ts
+++ b/packages/yuudachi/src/index.ts
@@ -116,11 +116,15 @@ try {
 	await client.login();
 
 	const wsURL = process.env.SCAM_DOMAIN_WS;
+	const identity = process.env.SCAM_DOMAIN_IDENTITY;
 
-	if (wsURL) {
+	if (wsURL && identity) {
 		new WebSocketConnection(process.env.SCAM_DOMAIN_WS!, scamDomainRequestHeaders.SCAM_DOMAIN_URL, redis);
 	} else {
-		logger.info(`Missing env var 'SCAM_DOMAIN_WS`);
+		logger.warn(`Missing env var 'SCAM_DOMAIN_WS or 'SCAM_DOMAIN_IDENTITY' to instantiate a WebSocketConnection`, {
+			wsURL,
+			identity,
+		});
 	}
 } catch (error_) {
 	const error = error_ as Error;

--- a/packages/yuudachi/src/websocket/WebSocketConnection.ts
+++ b/packages/yuudachi/src/websocket/WebSocketConnection.ts
@@ -14,6 +14,8 @@ export class WebSocketConnection {
 
 	private readonly url: string;
 
+	private readonly identity: string;
+
 	private readonly redis: Redis;
 
 	private readonly headers: { [key: string]: string } | undefined;
@@ -22,6 +24,7 @@ export class WebSocketConnection {
 
 	public constructor(url: string, headers: { [key: string]: string } | undefined, redis: Redis) {
 		this.url = url;
+		this.identity = process.env.SCAM_DOMAIN_IDENTITY!;
 		this.redis = redis;
 		this.headers = headers;
 		this.connection = new WebSocket(url, {
@@ -39,8 +42,9 @@ export class WebSocketConnection {
 
 	private onOpen() {
 		logger.info({
-			msg: `Websoket connected to ${this.url}`,
+			msg: `Websoket connected to ${this.url} as ${this.identity}`,
 			url: this.url,
+			identity: this.identity,
 		});
 		this.tries = 0;
 	}

--- a/packages/yuudachi/src/websocket/WebSocketConnection.ts
+++ b/packages/yuudachi/src/websocket/WebSocketConnection.ts
@@ -42,7 +42,7 @@ export class WebSocketConnection {
 
 	private onOpen() {
 		logger.info({
-			msg: `Websoket connected to ${this.url} as ${this.identity}`,
+			msg: `Websocket connected to ${this.url} as ${this.identity}`,
 			url: this.url,
 			identity: this.identity,
 		});

--- a/packages/yuudachi/src/websocket/WebSocketConnection.ts
+++ b/packages/yuudachi/src/websocket/WebSocketConnection.ts
@@ -42,7 +42,7 @@ export class WebSocketConnection {
 
 	private onOpen() {
 		logger.info({
-			msg: `Websocket connected to ${this.url} as ${this.identity}`,
+			msg: `WebSocket connected to ${this.url} as ${this.identity}`,
 			url: this.url,
 			identity: this.identity,
 		});


### PR DESCRIPTION
## Why?
Since this bot is open source, all of the forks and local instances rely on the same `X-Identity` header which could cause issues regarding FishFish logging and abuse prevention

> **Note**
> This PR implements a new `env` variable called `SCAM_DOMAIN_IDENTITY`

> **Warning**
> **The anti-scam will refuse to connect to the WS (the WS also refuses connections without the `X-Identity` header) of fetch domain information without this env (Only discord hashes will be cached)**

### This PR closes #1115 