### PR TITLE
perf(update): improve update functions to only use one db call

### DIFF
--- a/packages/yuudachi/src/functions/cases/updateCase.ts
+++ b/packages/yuudachi/src/functions/cases/updateCase.ts
@@ -13,7 +13,7 @@ export type PatchCase = Pick<
 export async function updateCase(case_: PatchCase) {
 	const sql = container.resolve<Sql<any>>(kSQL);
 
-	const queries: Partial<Record<keyof RawCase, unknown>> = {
+	const updates: Partial<Record<keyof RawCase, unknown>> = {
 		action_expiration: case_.actionExpiration,
 		reason: case_.reason,
 		context_message_id: case_.contextMessageId,
@@ -21,10 +21,10 @@ export async function updateCase(case_: PatchCase) {
 		report_ref_id: case_.reportRefId,
 	};
 
-	const updates = removeUndefinedKeys(queries);
+	const queries = removeUndefinedKeys(updates);
 
 	const [updatedCase] = await sql<[RawCase]>`
-		update cases set ${sql(updates as Record<string, unknown>, ...Object.keys(updates))}
+		update cases set ${sql(queries as Record<string, unknown>, ...Object.keys(queries))}
 		where guild_id = ${case_.guildId}
 			and case_id = ${case_.caseId!}
 		returning *

--- a/packages/yuudachi/src/functions/cases/updateCase.ts
+++ b/packages/yuudachi/src/functions/cases/updateCase.ts
@@ -1,6 +1,7 @@
 import type { Sql } from "postgres";
 import { container } from "tsyringe";
 import { kSQL } from "../../tokens.js";
+import { removeUndefinedKeys } from "../../util/object.js";
 import type { CreateCase } from "./createCase.js";
 import { type RawCase, transformCase } from "./transformCase.js";
 
@@ -12,56 +13,21 @@ export type PatchCase = Pick<
 export async function updateCase(case_: PatchCase) {
 	const sql = container.resolve<Sql<any>>(kSQL);
 
-	if (case_.actionExpiration) {
-		await sql`
-			update cases
-			set action_expiration = ${case_.actionExpiration}
-			where guild_id = ${case_.guildId}
-				and case_id = ${case_.caseId!}
-		`;
-	}
+	const queries: Partial<Record<keyof RawCase, unknown>> = {
+		action_expiration: case_.actionExpiration,
+		reason: case_.reason,
+		context_message_id: case_.contextMessageId,
+		ref_id: case_.refId,
+		report_ref_id: case_.reportRefId,
+	};
 
-	if (case_.reason) {
-		await sql`
-			update cases
-			set reason = ${case_.reason}
-			where guild_id = ${case_.guildId}
-				and case_id = ${case_.caseId!}
-		`;
-	}
-
-	if (case_.contextMessageId) {
-		await sql`
-			update cases
-			set context_message_id = ${case_.contextMessageId}
-			where guild_id = ${case_.guildId}
-				and case_id = ${case_.caseId!}
-		`;
-	}
-
-	if (case_.refId) {
-		await sql`
-			update cases
-			set ref_id = ${case_.refId}
-			where guild_id = ${case_.guildId}
-				and case_id = ${case_.caseId!}
-		`;
-	}
-
-	if (case_.reportRefId) {
-		await sql`
-			update cases
-			set report_ref_id = ${case_.reportRefId}
-			where guild_id = ${case_.guildId}
-				and case_id = ${case_.caseId!}
-		`;
-	}
+	const updates = removeUndefinedKeys(queries);
 
 	const [updatedCase] = await sql<[RawCase]>`
-		select *
-		from cases
+		update cases set ${sql(updates as Record<string, unknown>, ...Object.keys(updates))}
 		where guild_id = ${case_.guildId}
 			and case_id = ${case_.caseId!}
+		returning *
 	`;
 
 	return transformCase(updatedCase);

--- a/packages/yuudachi/src/functions/reports/updateReport.ts
+++ b/packages/yuudachi/src/functions/reports/updateReport.ts
@@ -14,7 +14,7 @@ export type PatchReport = Pick<
 export async function updateReport(report: PatchReport, moderator?: User) {
 	const sql = container.resolve<Sql<any>>(kSQL);
 
-	const queries: Partial<Record<keyof RawReport, unknown>> = {
+	const updates: Partial<Record<keyof RawReport, unknown>> = {
 		status: report.status,
 		attachment_url: report.attachmentUrl,
 		reason: report.reason,
@@ -25,10 +25,10 @@ export async function updateReport(report: PatchReport, moderator?: User) {
 		mod_tag: moderator?.tag,
 	};
 
-	const updates = removeUndefinedKeys(queries);
+	const queries = removeUndefinedKeys(updates);
 
 	const [updatedCase] = await sql<[RawReport]>`
-		update reports set ${sql(updates as Record<string, unknown>, ...Object.keys(updates))}
+		update reports set ${sql(queries as Record<string, unknown>, ...Object.keys(queries))}
 		where guild_id = ${report.guildId}
 			and report_id = ${report.reportId!}
 		returning *

--- a/packages/yuudachi/src/functions/reports/updateReport.ts
+++ b/packages/yuudachi/src/functions/reports/updateReport.ts
@@ -2,6 +2,7 @@ import type { User } from "discord.js";
 import type { Sql } from "postgres";
 import { container } from "tsyringe";
 import { kSQL } from "../../tokens.js";
+import { removeUndefinedKeys } from "../../util/object.js";
 import type { CreateReport } from "./createReport.js";
 import { type RawReport, transformReport } from "./transformReport.js";
 
@@ -13,67 +14,24 @@ export type PatchReport = Pick<
 export async function updateReport(report: PatchReport, moderator?: User) {
 	const sql = container.resolve<Sql<any>>(kSQL);
 
-	if (report.status) {
-		await sql`
-			update reports
-			set status = ${report.status}
-			where guild_id = ${report.guildId}
-				and report_id = ${report.reportId!}
-		`;
-	}
+	const queries: Partial<Record<keyof RawReport, unknown>> = {
+		status: report.status,
+		attachment_url: report.attachmentUrl,
+		reason: report.reason,
+		message_id: report.message?.id,
+		channel_id: report.message?.channel.id,
+		ref_id: report.refId,
+		mod_id: moderator?.id,
+		mod_tag: moderator?.tag,
+	};
 
-	if (report.attachmentUrl) {
-		await sql`
-			update reports
-			set attachment_url = ${report.attachmentUrl}
-			where guild_id = ${report.guildId}
-				and report_id = ${report.reportId!}
-		`;
-	}
-
-	if (report.reason) {
-		await sql`
-			update reports
-			set reason = ${report.reason}
-			where guild_id = ${report.guildId}
-				and report_id = ${report.reportId!}
-		`;
-	}
-
-	if (report.message) {
-		await sql`
-			update reports
-			set message_id = ${report.message.id},
-				channel_id = ${report.message.channel.id}
-			where guild_id = ${report.guildId}
-				and report_id = ${report.reportId!}
-		`;
-	}
-
-	if (report.refId) {
-		await sql`
-			update reports
-			set ref_id = ${report.refId}
-			where guild_id = ${report.guildId}
-				and report_id = ${report.reportId!}
-		`;
-	}
-
-	if (moderator) {
-		await sql`
-			update reports
-			set mod_id = ${moderator.id},
-				mod_tag = ${moderator.tag}
-			where guild_id = ${report.guildId}
-				and report_id = ${report.reportId!}
-		`;
-	}
+	const updates = removeUndefinedKeys(queries);
 
 	const [updatedCase] = await sql<[RawReport]>`
-		select *
-		from reports
+		update reports set ${sql(updates as Record<string, unknown>, ...Object.keys(updates))}
 		where guild_id = ${report.guildId}
 			and report_id = ${report.reportId!}
+		returning *
 	`;
 
 	return transformReport(updatedCase);

--- a/packages/yuudachi/src/util/object.ts
+++ b/packages/yuudachi/src/util/object.ts
@@ -1,0 +1,9 @@
+export function removeUndefinedKeys<T extends Record<string, unknown>>(obj: T): T {
+	return Object.entries(obj).reduce<Record<string, unknown>>((acc, [key, value]) => {
+		if (value !== undefined) {
+			acc[key] = value;
+		}
+
+		return acc;
+	}, {}) as T;
+}


### PR DESCRIPTION
> **Note**
> I think this is the first PR that I didn't need to use this field, but why not use it anyway?

## Why?
The old function is used an if the chain is combined with multiple PGs calls (including one for returning the new obj), this new approach uses objects combined with the [`SQL helpers`](https://github.com/porsager/postgres#dynamic-columns-in-updates) to provide a single and versatile DB call, while also using the `returning *` statement to return the updated object in the same call


#### Utils and references
- [Discord Thread](https://canary.discord.com/channels/222078108977594368/1018720734614392902/1018720734614392902)
- [Will initial proposal](https://github.com/Naval-Base/yuudachi/pull/1103#discussion_r947360549)
- [Based on this docs](https://github.com/porsager/postgres#dynamic-columns-in-updates)

*Sorry for another PR Crawl*