### PR TITLE
fix(reasons): Remove autocomplete from non applicable commands

### DIFF
--- a/packages/yuudachi/src/interactions/moderation/anti-raid-nuke.ts
+++ b/packages/yuudachi/src/interactions/moderation/anti-raid-nuke.ts
@@ -69,7 +69,6 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
-					autocomplete: true,
 				},
 				{
 					name: "days",
@@ -108,7 +107,6 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
-					autocomplete: true,
 				},
 				{
 					name: "days",
@@ -141,7 +139,6 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
-					autocomplete: true,
 				},
 				{
 					name: "days",

--- a/packages/yuudachi/src/interactions/moderation/unban.ts
+++ b/packages/yuudachi/src/interactions/moderation/unban.ts
@@ -14,7 +14,6 @@ export const UnbanCommand = {
 			name: "reason",
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
-			autocomplete: true,
 		},
 		{
 			name: "report_reference",


### PR DESCRIPTION
## Why?
The reasons used for quick reasons don't fit the purpose of the `Unban` and `anti-raid-nuke` commands!

> **Note**
> This PR requires a command deploy

> Closes #1126 