### PR TITLE
refactor(commands): implement native string validation

### DIFF
--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -39,7 +39,7 @@
 		"mod": {
 			"common": {
 				"errors": {
-					"max_length_reason": "Maximum length of `500` for reason exceeded.",
+					"max_length_reason": "Maximum length of `{{ reason_max_length}}` for reason exceeded.",
 					"not_a_text_channel": "{{- channel}} is not a text channel.",
 					"no_case": "Cannot find case `#{{case}}`",
 					"no_report": "Cannot find report `#{{report}}`",

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -39,7 +39,7 @@
 		"mod": {
 			"common": {
 				"errors": {
-					"max_length_reason": "Maximum length of `1900` for reason exceeded.",
+					"max_length_reason": "Maximum length of `500` for reason exceeded.",
 					"not_a_text_channel": "{{- channel}} is not a text channel.",
 					"no_case": "Cannot find case `#{{case}}`",
 					"no_report": "Cannot find report `#{{report}}`",
@@ -717,8 +717,16 @@
 				}
 			},
 			"table": {
-				"success_titles": ["Case id", "Member id", "Username"],
-				"fail_titles": ["Member id", "Username", "Error"]
+				"success_titles": [
+					"Case id",
+					"Member id",
+					"Username"
+				],
+				"fail_titles": [
+					"Member id",
+					"Username",
+					"Error"
+				]
 			}
 		},
 		"report_log": {

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -717,16 +717,8 @@
 				}
 			},
 			"table": {
-				"success_titles": [
-					"Case id",
-					"Member id",
-					"Username"
-				],
-				"fail_titles": [
-					"Member id",
-					"Username",
-					"Error"
-				]
+				"success_titles": ["Case id", "Member id", "Username"],
+				"fail_titles": ["Member id", "Username", "Error"]
 			}
 		},
 		"report_log": {

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -39,7 +39,7 @@
 		"mod": {
 			"common": {
 				"errors": {
-					"max_length_reason": "Maximum length of `{{ reason_max_length}}` for reason exceeded.",
+					"max_length_reason": "Maximum length of `{{reason_max_length}}` for reason exceeded.",
 					"not_a_text_channel": "{{- channel}} is not a text channel.",
 					"no_case": "Cannot find case `#{{case}}`",
 					"no_report": "Cannot find report `#{{report}}`",

--- a/packages/yuudachi/src/Constants.ts
+++ b/packages/yuudachi/src/Constants.ts
@@ -22,6 +22,9 @@ export const enum ThreatLevelColor {
 
 export const OP_DELIMITER = "-";
 
+export const CASE_REASON_MAX_LENGTH = 500;
+export const CASE_REASON_MIN_LENGTH = 3;
+
 export const MAX_TRUST_ACCOUNT_AGE = 1_000 * 60 * 60 * 24 * 7 * 4;
 export const SPAM_THRESHOLD = 4;
 export const SPAM_EXPIRE_SECONDS = 30;
@@ -36,6 +39,7 @@ export const AUDIT_LOG_WAIT_SECONDS = 2.5;
 
 export const HISTORY_DESCRIPTION_MAX_LENGTH = 80;
 export const REPORT_REASON_MAX_LENGTH = 1_500;
+export const REPORT_REASON_MIN_LENGTH = 1_500;
 
 export const REPORT_DUPLICATE_EXPIRE_SECONDS = 15 * 60;
 export const REPORT_MESSAGE_CONTEXT_LIMIT = 20;

--- a/packages/yuudachi/src/commands/moderation/ban.ts
+++ b/packages/yuudachi/src/commands/moderation/ban.ts
@@ -5,6 +5,7 @@ import type { Redis } from "ioredis";
 import { nanoid } from "nanoid";
 import { inject, injectable } from "tsyringe";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam } from "../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../Constants.js";
 import { CaseAction, createCase } from "../../functions/cases/createCase.js";
 import { generateCasePayload } from "../../functions/logging/generateCasePayload.js";
 import { upsertCaseLog } from "../../functions/logging/upsertCaseLog.js";
@@ -64,8 +65,13 @@ export default class extends Command<typeof BanCommand> {
 			);
 		}
 
-		if (args.reason && args.reason.length >= 500) {
-			throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+		if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+			throw new Error(
+				i18next.t("command.mod.common.errors.max_length_reason", {
+					reason_max_length: CASE_REASON_MAX_LENGTH,
+					lng: locale,
+				}),
+			);
 		}
 
 		const banKey = nanoid();

--- a/packages/yuudachi/src/commands/moderation/kick.ts
+++ b/packages/yuudachi/src/commands/moderation/kick.ts
@@ -5,6 +5,7 @@ import type { Redis } from "ioredis";
 import { nanoid } from "nanoid";
 import { inject, injectable } from "tsyringe";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam } from "../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../Constants.js";
 import { createCase, CaseAction } from "../../functions/cases/createCase.js";
 import { generateCasePayload } from "../../functions/logging/generateCasePayload.js";
 import { upsertCaseLog } from "../../functions/logging/upsertCaseLog.js";
@@ -57,8 +58,13 @@ export default class extends Command<typeof KickCommand> {
 			);
 		}
 
-		if (args.reason && args.reason.length >= 500) {
-			throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+		if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+			throw new Error(
+				i18next.t("command.mod.common.errors.max_length_reason", {
+					reason_max_length: CASE_REASON_MAX_LENGTH,
+					lng: locale,
+				}),
+			);
 		}
 
 		const kickKey = nanoid();

--- a/packages/yuudachi/src/commands/moderation/lockdown.ts
+++ b/packages/yuudachi/src/commands/moderation/lockdown.ts
@@ -1,6 +1,7 @@
 import { type TextChannel, ChannelType, PermissionFlagsBits } from "discord.js";
 import i18next from "i18next";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam } from "../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../Constants.js";
 import type { LockdownCommand } from "../../interactions/index.js";
 import { lift } from "./sub/lockdown/lift.js";
 import { lock } from "./sub/lockdown/lock.js";
@@ -34,8 +35,13 @@ export default class extends Command<typeof LockdownCommand> {
 
 				const reason = args.lock.reason;
 
-				if (reason && reason.length >= 1_900) {
-					throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+				if (args.lock.reason && args.lock.reason.length >= CASE_REASON_MAX_LENGTH) {
+					throw new Error(
+						i18next.t("command.mod.common.errors.max_length_reason", {
+							reason_max_length: CASE_REASON_MAX_LENGTH,
+							lng: locale,
+						}),
+					);
 				}
 
 				const targetChannel = (args.lock.channel ?? interaction.channel) as TextChannel;

--- a/packages/yuudachi/src/commands/moderation/reason.ts
+++ b/packages/yuudachi/src/commands/moderation/reason.ts
@@ -2,6 +2,7 @@ import { ComponentType, ButtonStyle, hyperlink, messageLink } from "discord.js";
 import i18next from "i18next";
 import { nanoid } from "nanoid";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam } from "../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../Constants.js";
 import type { Case } from "../../functions/cases/createCase.js";
 import { getCase } from "../../functions/cases/getCase.js";
 import { updateCase } from "../../functions/cases/updateCase.js";
@@ -31,8 +32,13 @@ export default class extends Command<typeof ReasonCommand> {
 			throw new Error(i18next.t("common.errors.no_mod_log_channel", { lng: locale }));
 		}
 
-		if (args.reason.length >= 500) {
-			throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+		if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+			throw new Error(
+				i18next.t("command.mod.common.errors.max_length_reason", {
+					reason_max_length: CASE_REASON_MAX_LENGTH,
+					lng: locale,
+				}),
+			);
 		}
 
 		const lower = Math.min(args.case, args.last_case ?? args.case);

--- a/packages/yuudachi/src/commands/moderation/softban.ts
+++ b/packages/yuudachi/src/commands/moderation/softban.ts
@@ -5,6 +5,7 @@ import type { Redis } from "ioredis";
 import { nanoid } from "nanoid";
 import { inject, injectable } from "tsyringe";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam } from "../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../Constants.js";
 import { CaseAction, createCase } from "../../functions/cases/createCase.js";
 import { generateCasePayload } from "../../functions/logging/generateCasePayload.js";
 import { upsertCaseLog } from "../../functions/logging/upsertCaseLog.js";
@@ -49,11 +50,16 @@ export default class extends Command<typeof SoftbanCommand> {
 			);
 		}
 
-		const isStillMember = interaction.guild.members.resolve(args.user.user.id);
-
-		if (args.reason && args.reason.length >= 500) {
-			throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+		if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+			throw new Error(
+				i18next.t("command.mod.common.errors.max_length_reason", {
+					reason_max_length: CASE_REASON_MAX_LENGTH,
+					lng: locale,
+				}),
+			);
 		}
+
+		const isStillMember = interaction.guild.members.resolve(args.user.user.id);
 
 		const softbanKey = nanoid();
 		const cancelKey = nanoid();

--- a/packages/yuudachi/src/commands/moderation/sub/restrict/embed.ts
+++ b/packages/yuudachi/src/commands/moderation/sub/restrict/embed.ts
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 import type { Sql } from "postgres";
 import { container } from "tsyringe";
 import type { InteractionParam, ArgsParam, LocaleParam } from "../../../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../../../Constants.js";
 import { CaseAction, createCase } from "../../../../functions/cases/createCase.js";
 import { generateCasePayload } from "../../../../functions/logging/generateCasePayload.js";
 import { upsertCaseLog } from "../../../../functions/logging/upsertCaseLog.js";
@@ -29,8 +30,13 @@ export async function embed(
 		);
 	}
 
-	if (args.reason && args.reason.length >= 500) {
-		throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+	if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+		throw new Error(
+			i18next.t("command.mod.common.errors.max_length_reason", {
+				reason_max_length: CASE_REASON_MAX_LENGTH,
+				lng: locale,
+			}),
+		);
 	}
 
 	const sql = container.resolve<Sql<any>>(kSQL);

--- a/packages/yuudachi/src/commands/moderation/sub/restrict/emoji.ts
+++ b/packages/yuudachi/src/commands/moderation/sub/restrict/emoji.ts
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 import type { Sql } from "postgres";
 import { container } from "tsyringe";
 import type { InteractionParam, ArgsParam, LocaleParam } from "../../../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../../../Constants.js";
 import { CaseAction, createCase } from "../../../../functions/cases/createCase.js";
 import { generateCasePayload } from "../../../../functions/logging/generateCasePayload.js";
 import { upsertCaseLog } from "../../../../functions/logging/upsertCaseLog.js";
@@ -29,8 +30,13 @@ export async function emoji(
 		);
 	}
 
-	if (args.reason && args.reason.length >= 500) {
-		throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+	if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+		throw new Error(
+			i18next.t("command.mod.common.errors.max_length_reason", {
+				reason_max_length: CASE_REASON_MAX_LENGTH,
+				lng: locale,
+			}),
+		);
 	}
 
 	const sql = container.resolve<Sql<any>>(kSQL);

--- a/packages/yuudachi/src/commands/moderation/sub/restrict/react.ts
+++ b/packages/yuudachi/src/commands/moderation/sub/restrict/react.ts
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 import type { Sql } from "postgres";
 import { container } from "tsyringe";
 import type { InteractionParam, ArgsParam, LocaleParam } from "../../../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../../../Constants.js";
 import { CaseAction, createCase } from "../../../../functions/cases/createCase.js";
 import { generateCasePayload } from "../../../../functions/logging/generateCasePayload.js";
 import { upsertCaseLog } from "../../../../functions/logging/upsertCaseLog.js";
@@ -29,8 +30,13 @@ export async function react(
 		);
 	}
 
-	if (args.reason && args.reason.length >= 500) {
-		throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+	if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+		throw new Error(
+			i18next.t("command.mod.common.errors.max_length_reason", {
+				reason_max_length: CASE_REASON_MAX_LENGTH,
+				lng: locale,
+			}),
+		);
 	}
 
 	const sql = container.resolve<Sql<any>>(kSQL);

--- a/packages/yuudachi/src/commands/moderation/timeout.ts
+++ b/packages/yuudachi/src/commands/moderation/timeout.ts
@@ -6,6 +6,7 @@ import type { Redis } from "ioredis";
 import { nanoid } from "nanoid";
 import { inject, injectable } from "tsyringe";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam } from "../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../Constants.js";
 import { CaseAction, createCase } from "../../functions/cases/createCase.js";
 import { generateCasePayload } from "../../functions/logging/generateCasePayload.js";
 import { upsertCaseLog } from "../../functions/logging/upsertCaseLog.js";
@@ -71,8 +72,13 @@ export default class extends Command<typeof TimeoutCommand> {
 			);
 		}
 
-		if (args.reason && args.reason.length >= 500) {
-			throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+		if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+			throw new Error(
+				i18next.t("command.mod.common.errors.max_length_reason", {
+					reason_max_length: CASE_REASON_MAX_LENGTH,
+					lng: locale,
+				}),
+			);
 		}
 
 		const timeoutKey = nanoid();

--- a/packages/yuudachi/src/commands/moderation/unban.ts
+++ b/packages/yuudachi/src/commands/moderation/unban.ts
@@ -5,6 +5,7 @@ import type { Redis } from "ioredis";
 import { nanoid } from "nanoid";
 import { inject, injectable } from "tsyringe";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam } from "../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../Constants.js";
 import { deleteCase } from "../../functions/cases/deleteCase.js";
 import { upsertCaseLog } from "../../functions/logging/upsertCaseLog.js";
 import { checkLogChannel } from "../../functions/settings/checkLogChannel.js";
@@ -50,8 +51,13 @@ export default class extends Command<typeof UnbanCommand> {
 			);
 		}
 
-		if (args.reason && args.reason.length >= 500) {
-			throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+		if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+			throw new Error(
+				i18next.t("command.mod.common.errors.max_length_reason", {
+					reason_max_length: CASE_REASON_MAX_LENGTH,
+					lng: locale,
+				}),
+			);
 		}
 
 		const unbanKey = nanoid();

--- a/packages/yuudachi/src/commands/moderation/warn.ts
+++ b/packages/yuudachi/src/commands/moderation/warn.ts
@@ -2,6 +2,7 @@ import { ButtonStyle, ComponentType } from "discord.js";
 import i18next from "i18next";
 import { nanoid } from "nanoid";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam } from "../../Command.js";
+import { CASE_REASON_MAX_LENGTH } from "../../Constants.js";
 import { CaseAction, createCase } from "../../functions/cases/createCase.js";
 import { generateCasePayload } from "../../functions/logging/generateCasePayload.js";
 import { upsertCaseLog } from "../../functions/logging/upsertCaseLog.js";
@@ -39,8 +40,13 @@ export default class extends Command<typeof WarnCommand> {
 			);
 		}
 
-		if (args.reason && args.reason.length >= 500) {
-			throw new Error(i18next.t("command.mod.common.errors.max_length_reason", { lng: locale }));
+		if (args.reason && args.reason.length >= CASE_REASON_MAX_LENGTH) {
+			throw new Error(
+				i18next.t("command.mod.common.errors.max_length_reason", {
+					reason_max_length: CASE_REASON_MAX_LENGTH,
+					lng: locale,
+				}),
+			);
 		}
 
 		const warnKey = nanoid();

--- a/packages/yuudachi/src/commands/utility/report.ts
+++ b/packages/yuudachi/src/commands/utility/report.ts
@@ -5,7 +5,7 @@ import type { Redis } from "ioredis";
 import { nanoid } from "nanoid";
 import { inject, injectable } from "tsyringe";
 import { type ArgsParam, Command, type InteractionParam, type LocaleParam, type CommandMethod } from "../../Command.js";
-import { REPORT_REASON_MAX_LENGTH } from "../../Constants.js";
+import { REPORT_REASON_MAX_LENGTH, REPORT_REASON_MIN_LENGTH } from "../../Constants.js";
 import { checkLogChannel } from "../../functions/settings/checkLogChannel.js";
 import { getGuildSetting, SettingsKeys } from "../../functions/settings/getGuildSetting.js";
 import type { ReportCommand, ReportMessageContextCommand, ReportUserContextCommand } from "../../interactions/index.js";
@@ -127,7 +127,7 @@ export default class extends Command<
 					createTextComponent({
 						customId: "reason",
 						label: i18next.t("command.utility.report.common.modal.label", { lng: locale }),
-						minLength: 10,
+						minLength: REPORT_REASON_MIN_LENGTH,
 						maxLength: REPORT_REASON_MAX_LENGTH,
 						placeholder: i18next.t("command.utility.report.common.modal.placeholder", { lng: locale }),
 						required: true,
@@ -210,7 +210,7 @@ export default class extends Command<
 					createTextComponent({
 						customId: "reason",
 						label: i18next.t("command.utility.report.common.modal.label", { lng: locale }),
-						minLength: 10,
+						minLength: REPORT_REASON_MIN_LENGTH,
 						maxLength: REPORT_REASON_MAX_LENGTH,
 						placeholder: i18next.t("command.utility.report.common.modal.placeholder", { lng: locale }),
 						required: true,

--- a/packages/yuudachi/src/interactions/moderation/anti-raid-nuke.ts
+++ b/packages/yuudachi/src/interactions/moderation/anti-raid-nuke.ts
@@ -69,6 +69,8 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
+					min_length: 3,
+					max_length: 500,
 				},
 				{
 					name: "days",
@@ -107,6 +109,8 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
+					min_length: 3,
+					max_length: 500,
 				},
 				{
 					name: "days",
@@ -139,6 +143,8 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
+					min_length: 3,
+					max_length: 500,
 				},
 				{
 					name: "days",

--- a/packages/yuudachi/src/interactions/moderation/anti-raid-nuke.ts
+++ b/packages/yuudachi/src/interactions/moderation/anti-raid-nuke.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const AntiRaidNukeCommand = {
 	name: "anti-raid-nuke",
@@ -69,8 +70,8 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
-					min_length: 3,
-					max_length: 500,
+					min_length: CASE_REASON_MIN_LENGTH,
+					max_length: CASE_REASON_MAX_LENGTH,
 				},
 				{
 					name: "days",
@@ -109,8 +110,8 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
-					min_length: 3,
-					max_length: 500,
+					min_length: CASE_REASON_MIN_LENGTH,
+					max_length: CASE_REASON_MAX_LENGTH,
 				},
 				{
 					name: "days",
@@ -143,8 +144,8 @@ export const AntiRaidNukeCommand = {
 					name: "reason",
 					description: "The reason to ban the members",
 					type: ApplicationCommandOptionType.String,
-					min_length: 3,
-					max_length: 500,
+					min_length: CASE_REASON_MIN_LENGTH,
+					max_length: CASE_REASON_MAX_LENGTH,
 				},
 				{
 					name: "days",

--- a/packages/yuudachi/src/interactions/moderation/ban.ts
+++ b/packages/yuudachi/src/interactions/moderation/ban.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const BanCommand = {
 	name: "ban",
@@ -15,8 +16,8 @@ export const BanCommand = {
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
-			min_length: 3,
-			max_length: 500,
+			min_length: CASE_REASON_MIN_LENGTH,
+			max_length: CASE_REASON_MAX_LENGTH,
 		},
 		{
 			name: "days",

--- a/packages/yuudachi/src/interactions/moderation/ban.ts
+++ b/packages/yuudachi/src/interactions/moderation/ban.ts
@@ -15,6 +15,8 @@ export const BanCommand = {
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
+			min_length: 3,
+			max_length: 500,
 		},
 		{
 			name: "days",

--- a/packages/yuudachi/src/interactions/moderation/kick.ts
+++ b/packages/yuudachi/src/interactions/moderation/kick.ts
@@ -15,6 +15,8 @@ export const KickCommand = {
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
+			min_length: 3,
+			max_length: 500,
 		},
 		{
 			name: "case_reference",

--- a/packages/yuudachi/src/interactions/moderation/kick.ts
+++ b/packages/yuudachi/src/interactions/moderation/kick.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const KickCommand = {
 	name: "kick",
@@ -15,8 +16,8 @@ export const KickCommand = {
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
-			min_length: 3,
-			max_length: 500,
+			min_length: CASE_REASON_MIN_LENGTH,
+			max_length: CASE_REASON_MAX_LENGTH,
 		},
 		{
 			name: "case_reference",

--- a/packages/yuudachi/src/interactions/moderation/lockdown.ts
+++ b/packages/yuudachi/src/interactions/moderation/lockdown.ts
@@ -34,6 +34,8 @@ export const LockdownCommand = {
 					name: "reason",
 					description: "The reason of this lockdown",
 					type: ApplicationCommandOptionType.String,
+					min_length: 3,
+					max_length: 500,
 				},
 			],
 		},

--- a/packages/yuudachi/src/interactions/moderation/reason.ts
+++ b/packages/yuudachi/src/interactions/moderation/reason.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const ReasonCommand = {
 	name: "reason",
@@ -16,8 +17,8 @@ export const ReasonCommand = {
 			type: ApplicationCommandOptionType.String,
 			required: true,
 			autocomplete: true,
-			min_length: 3,
-			max_length: 500,
+			min_length: CASE_REASON_MIN_LENGTH,
+			max_length: CASE_REASON_MAX_LENGTH,
 		},
 		{
 			name: "last_case",

--- a/packages/yuudachi/src/interactions/moderation/reason.ts
+++ b/packages/yuudachi/src/interactions/moderation/reason.ts
@@ -16,6 +16,8 @@ export const ReasonCommand = {
 			type: ApplicationCommandOptionType.String,
 			required: true,
 			autocomplete: true,
+			min_length: 3,
+			max_length: 500,
 		},
 		{
 			name: "last_case",

--- a/packages/yuudachi/src/interactions/moderation/restrict.ts
+++ b/packages/yuudachi/src/interactions/moderation/restrict.ts
@@ -35,6 +35,8 @@ export const RestrictCommand = {
 					description: "The reason of this action",
 					type: ApplicationCommandOptionType.String,
 					autocomplete: true,
+					min_length: 3,
+					max_length: 500,
 				},
 				{
 					name: "case_reference",
@@ -79,6 +81,8 @@ export const RestrictCommand = {
 					description: "The reason of this action",
 					type: ApplicationCommandOptionType.String,
 					autocomplete: true,
+					min_length: 3,
+					max_length: 500,
 				},
 				{
 					name: "case_reference",
@@ -123,6 +127,8 @@ export const RestrictCommand = {
 					description: "The reason of this action",
 					type: ApplicationCommandOptionType.String,
 					autocomplete: true,
+					min_length: 3,
+					max_length: 500,
 				},
 				{
 					name: "case_reference",

--- a/packages/yuudachi/src/interactions/moderation/restrict.ts
+++ b/packages/yuudachi/src/interactions/moderation/restrict.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const RestrictCommand = {
 	name: "restrict",
@@ -35,8 +36,8 @@ export const RestrictCommand = {
 					description: "The reason of this action",
 					type: ApplicationCommandOptionType.String,
 					autocomplete: true,
-					min_length: 3,
-					max_length: 500,
+					min_length: CASE_REASON_MIN_LENGTH,
+					max_length: CASE_REASON_MAX_LENGTH,
 				},
 				{
 					name: "case_reference",
@@ -81,8 +82,8 @@ export const RestrictCommand = {
 					description: "The reason of this action",
 					type: ApplicationCommandOptionType.String,
 					autocomplete: true,
-					min_length: 3,
-					max_length: 500,
+					min_length: CASE_REASON_MIN_LENGTH,
+					max_length: CASE_REASON_MAX_LENGTH,
 				},
 				{
 					name: "case_reference",
@@ -127,8 +128,8 @@ export const RestrictCommand = {
 					description: "The reason of this action",
 					type: ApplicationCommandOptionType.String,
 					autocomplete: true,
-					min_length: 3,
-					max_length: 500,
+					min_length: CASE_REASON_MIN_LENGTH,
+					max_length: CASE_REASON_MAX_LENGTH,
 				},
 				{
 					name: "case_reference",

--- a/packages/yuudachi/src/interactions/moderation/softban.ts
+++ b/packages/yuudachi/src/interactions/moderation/softban.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const SoftbanCommand = {
 	name: "softban",
@@ -15,8 +16,8 @@ export const SoftbanCommand = {
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
-			min_length: 3,
-			max_length: 500,
+			min_length: CASE_REASON_MIN_LENGTH,
+			max_length: CASE_REASON_MAX_LENGTH,
 		},
 		{
 			name: "days",

--- a/packages/yuudachi/src/interactions/moderation/softban.ts
+++ b/packages/yuudachi/src/interactions/moderation/softban.ts
@@ -15,6 +15,8 @@ export const SoftbanCommand = {
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
+			min_length: 3,
+			max_length: 500,
 		},
 		{
 			name: "days",

--- a/packages/yuudachi/src/interactions/moderation/timeout.ts
+++ b/packages/yuudachi/src/interactions/moderation/timeout.ts
@@ -34,6 +34,8 @@ export const TimeoutCommand = {
 			description: "The reason of this timeout",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
+			min_length: 3,
+			max_length: 500,
 		},
 		{
 			name: "case_reference",

--- a/packages/yuudachi/src/interactions/moderation/timeout.ts
+++ b/packages/yuudachi/src/interactions/moderation/timeout.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const TimeoutCommand = {
 	name: "timeout",
@@ -34,8 +35,8 @@ export const TimeoutCommand = {
 			description: "The reason of this timeout",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
-			min_length: 3,
-			max_length: 500,
+			min_length: CASE_REASON_MIN_LENGTH,
+			max_length: CASE_REASON_MAX_LENGTH,
 		},
 		{
 			name: "case_reference",

--- a/packages/yuudachi/src/interactions/moderation/unban.ts
+++ b/packages/yuudachi/src/interactions/moderation/unban.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const UnbanCommand = {
 	name: "unban",
@@ -14,8 +15,8 @@ export const UnbanCommand = {
 			name: "reason",
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
-			min_length: 3,
-			max_length: 500,
+			min_length: CASE_REASON_MIN_LENGTH,
+			max_length: CASE_REASON_MAX_LENGTH,
 		},
 		{
 			name: "report_reference",

--- a/packages/yuudachi/src/interactions/moderation/unban.ts
+++ b/packages/yuudachi/src/interactions/moderation/unban.ts
@@ -14,6 +14,8 @@ export const UnbanCommand = {
 			name: "reason",
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
+			min_length: 3,
+			max_length: 500,
 		},
 		{
 			name: "report_reference",

--- a/packages/yuudachi/src/interactions/moderation/warn.ts
+++ b/packages/yuudachi/src/interactions/moderation/warn.ts
@@ -15,6 +15,8 @@ export const WarnCommand = {
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
+			min_length: 3,
+			max_length: 500,
 		},
 		{
 			name: "case_reference",

--- a/packages/yuudachi/src/interactions/moderation/warn.ts
+++ b/packages/yuudachi/src/interactions/moderation/warn.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { CASE_REASON_MAX_LENGTH, CASE_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const WarnCommand = {
 	name: "warn",
@@ -15,8 +16,8 @@ export const WarnCommand = {
 			description: "The reason of this action",
 			type: ApplicationCommandOptionType.String,
 			autocomplete: true,
-			min_length: 3,
-			max_length: 500,
+			min_length: CASE_REASON_MIN_LENGTH,
+			max_length: CASE_REASON_MAX_LENGTH,
 		},
 		{
 			name: "case_reference",

--- a/packages/yuudachi/src/interactions/utility/report.ts
+++ b/packages/yuudachi/src/interactions/utility/report.ts
@@ -1,4 +1,5 @@
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { REPORT_REASON_MAX_LENGTH, REPORT_REASON_MIN_LENGTH } from "../../Constants.js";
 
 export const ReportCommand = {
 	name: "report",
@@ -20,8 +21,8 @@ export const ReportCommand = {
 					description: "Reason for the report",
 					type: ApplicationCommandOptionType.String,
 					required: true,
-					min_length: 10,
-					max_length: 1_500,
+					min_length: REPORT_REASON_MIN_LENGTH,
+					max_length: REPORT_REASON_MAX_LENGTH,
 				},
 			],
 		},
@@ -41,8 +42,8 @@ export const ReportCommand = {
 					description: "Reason for the report",
 					type: ApplicationCommandOptionType.String,
 					required: true,
-					min_length: 10,
-					max_length: 1_500,
+					min_length: REPORT_REASON_MIN_LENGTH,
+					max_length: REPORT_REASON_MAX_LENGTH,
 				},
 				{
 					name: "attachment",

--- a/packages/yuudachi/src/interactions/utility/report.ts
+++ b/packages/yuudachi/src/interactions/utility/report.ts
@@ -20,6 +20,8 @@ export const ReportCommand = {
 					description: "Reason for the report",
 					type: ApplicationCommandOptionType.String,
 					required: true,
+					min_length: 10,
+					max_length: 1_500,
 				},
 			],
 		},
@@ -39,6 +41,8 @@ export const ReportCommand = {
 					description: "Reason for the report",
 					type: ApplicationCommandOptionType.String,
 					required: true,
+					min_length: 10,
+					max_length: 1_500,
 				},
 				{
 					name: "attachment",


### PR DESCRIPTION
## Why?
Discord has an option to natively restrict string length so this PR implements the necessary changes for it

> **Note**
> This PR requires a command deployment

> **Note**
> The CI will fail because of the `yarn.lock` bug

> Closes #1131 