### PR TITLE
chore(logs): use tranlations for actions and add the case action to the reference

### DIFF
--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -473,12 +473,16 @@
 				},
 				"action_label": {
 					"restriction": "Restrict",
+					"restriction_case": "Role",
+					"unrestriction": "Unrestrict",
+					"unrestriction_case": "Unrole",
 					"warn": "Warn",
 					"kick": "Kick",
 					"softban": "Softban",
 					"ban": "Ban",
 					"unban": "Unban",
 					"timeout": "Timeout",
+					"timeout_end": "Timeout End",
 					"unknown": "Unknown"
 				}
 			},

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -512,7 +512,7 @@
 				"context_sub": "Beam me up, Yuu",
 				"reason": "\n**Reason:** {{- reason}}",
 				"reason_fallback": "\n**Reason:** Use `/reason {{case_id}} <...reason>` to set a reason for this case",
-				"case_reference": "\n**Case Reference:** {{- ref}}",
+				"case_reference": "\n**Case Reference:** {{- ref}} ({{action}})",
 				"report_reference": "\n**Report Reference:** {{- report_ref}}",
 				"footer": "Case {{case_id}}"
 			},

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -468,18 +468,18 @@
 					"softban_other": "{{count}} softbans",
 					"ban_one": "{{count}} ban",
 					"ban_other": "{{count}} bans",
-					"unban_one": "{{count}} unbans",
+					"unban_one": "{{count}} unban",
 					"unban_other": "{{count}} unbans"
 				},
 				"action_label": {
-					"restriction": "RESTRICT",
-					"warn": "WARN",
-					"kick": "KICK",
-					"softban": "SOFTBAN",
-					"ban": "BAN",
-					"unban": "UNBAN",
-					"timeout": "TIMEOUT",
-					"unknown": "UNKNOWN"
+					"restriction": "Restrict",
+					"warn": "Warn",
+					"kick": "Kick",
+					"softban": "Softban",
+					"ban": "Ban",
+					"unban": "Unban",
+					"timeout": "Timeout",
+					"unknown": "Unknown"
 				}
 			},
 			"reports": {
@@ -496,11 +496,11 @@
 					"spam_other": "{{count}} spam reports"
 				},
 				"status_label": {
-					"pending": "PENDING",
-					"approved": "APPROVED",
-					"rejected": "REJECTED",
-					"spam": "SPAM",
-					"unknown": "UNKNOWN"
+					"pending": "Pending",
+					"approved": "Approved",
+					"rejected": "Rejected",
+					"spam": "Spam",
+					"unknown": "Unknown"
 				}
 			}
 		},

--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -609,7 +609,7 @@
 			"message": "**Message:** {{- message_link}} ({{- channel}})",
 			"message_sub": "Beam me up, Yuu",
 			"message_fallback": "`Message deleted`",
-			"case_reference": "**Case Reference:** {{- ref}}",
+			"case_reference": "**Case Reference:** {{- ref}} ({{action}})",
 			"status": "**Status:** $t(log.report_log.report_status.{{status}})",
 			"moderator": "**Moderator:** {{- mod}}",
 			"updated_at": "**Updated at:** {{- updated_at}}",

--- a/packages/yuudachi/src/commands/moderation/case.ts
+++ b/packages/yuudachi/src/commands/moderation/case.ts
@@ -13,13 +13,14 @@ import { Collection, type Snowflake } from "discord.js";
 import i18next from "i18next";
 import type { Sql } from "postgres";
 import { OP_DELIMITER } from "../../Constants.js";
+import type { CaseAction } from "../../functions/cases/createCase.js";
 import { findCases } from "../../functions/cases/findCases.js";
 import { type RawCase, transformCase } from "../../functions/cases/transformCase.js";
 import { generateCaseEmbed } from "../../functions/logging/generateCaseEmbed.js";
 import { checkLogChannel } from "../../functions/settings/checkLogChannel.js";
 import { getGuildSetting, SettingsKeys } from "../../functions/settings/getGuildSetting.js";
 import type { CaseLookupCommand } from "../../interactions/index.js";
-import { ACTION_KEYS } from "../../util/actionKeys.js";
+import { caseActionLabel } from "../../util/actionKeys.js";
 import { generateHistory } from "../../util/generateHistory.js";
 import { resolveMemberAndUser } from "../../util/resolveMemberAndUser.js";
 
@@ -33,7 +34,9 @@ export default class extends Command<typeof CaseLookupCommand> {
 			const trimmedPhrase = args.phrase.trim();
 			const cases = await findCases(trimmedPhrase, interaction.guildId);
 			let choices = cases.map((case_) => {
-				const choiceName = `#${case_.case_id} ${ACTION_KEYS[case_.action]!.toUpperCase()} ${case_.target_tag}: ${
+				const choiceName = `#${case_.case_id} ${caseActionLabel(case_.action as CaseAction, locale).toUpperCase()} ${
+					case_.target_tag
+				}: ${
 					case_.reason ??
 					i18next.t("command.mod.case.autocomplete.no_reason", {
 						lng: locale,

--- a/packages/yuudachi/src/commands/moderation/reports.ts
+++ b/packages/yuudachi/src/commands/moderation/reports.ts
@@ -10,10 +10,11 @@ import type { ArgsParam, InteractionParam, LocaleParam, CommandMethod } from "@y
 import { Collection, type Snowflake } from "discord.js";
 import i18next from "i18next";
 import { OP_DELIMITER } from "../../Constants.js";
+import type { ReportStatus } from "../../functions/reports/createReport.js";
 import { ReportType } from "../../functions/reports/createReport.js";
 import { findReports } from "../../functions/reports/findReports.js";
 import type { ReportUtilsCommand } from "../../interactions/index.js";
-import { REPORT_KEYS } from "../../util/actionKeys.js";
+import { reportStatusLabel } from "../../util/actionKeys.js";
 import { lookup } from "./sub/reports/lookup.js";
 import { status } from "./sub/reports/status.js";
 
@@ -27,9 +28,11 @@ export default class extends Command<typeof ReportUtilsCommand> {
 			const trimmedPhrase = args.lookup.phrase.trim();
 			const reports = await findReports(trimmedPhrase, interaction.guildId);
 			let choices = reports.map((report) => {
-				const choiceName = `#${report.report_id} ${report.type === ReportType.Message ? "✉️" : "👤"} ${REPORT_KEYS[
-					report.status
-				]!.toUpperCase()} ${report.author_tag} ➜ ${report.target_tag}: ${report.reason}`;
+				const choiceName = `#${report.report_id} ${
+					report.type === ReportType.Message ? "✉️" : "👤"
+				} ${reportStatusLabel(report.status as ReportStatus, locale).toUpperCase()} ${report.author_tag} ➜ ${
+					report.target_tag
+				}: ${report.reason}`;
 
 				return {
 					name: ellipsis(choiceName, AUTOCOMPLETE_CHOICE_NAME_LENGTH_LIMIT),

--- a/packages/yuudachi/src/functions/logging/generateCaseLog.ts
+++ b/packages/yuudachi/src/functions/logging/generateCaseLog.ts
@@ -2,6 +2,7 @@ import { logger, kSQL, container } from "@yuudachi/framework";
 import { Client, type Snowflake, hyperlink, time, TimestampStyles, messageLink, channelLink } from "discord.js";
 import i18next from "i18next";
 import type { Sql } from "postgres";
+import { actionKeyLabel, ACTION_KEYS } from "../../util/actionKeys.js";
 import { type Case, CaseAction } from "../cases/createCase.js";
 import { getGuildSetting, SettingsKeys } from "../settings/getGuildSetting.js";
 
@@ -66,16 +67,17 @@ export async function generateCaseLog(case_: Case, logChannelId: Snowflake, loca
 	}
 
 	if (case_.refId) {
-		const [reference] = await sql<[{ log_message_id: Snowflake | null }?]>`
-			select log_message_id
+		const [reference] = await sql<[{ action: CaseAction; log_message_id: Snowflake | null }?]>`
+			select log_message_id, action
 			from cases
 			where guild_id = ${case_.guildId}
 				and case_id = ${case_.refId}
 		`;
 
-		if (Reflect.has(reference ?? {}, "log_message_id")) {
+		if (Reflect.has(reference ?? {}, "log_message_id") && Reflect.has(reference ?? {}, "action")) {
 			msg += i18next.t("log.mod_log.case_log.case_reference", {
 				ref: hyperlink(`#${case_.refId}`, messageLink(logChannelId, reference!.log_message_id!, case_.guildId)),
+				action: actionKeyLabel(ACTION_KEYS[reference!.action], locale),
 				lng: locale,
 			});
 		}

--- a/packages/yuudachi/src/functions/logging/generateCaseLog.ts
+++ b/packages/yuudachi/src/functions/logging/generateCaseLog.ts
@@ -68,13 +68,13 @@ export async function generateCaseLog(case_: Case, logChannelId: Snowflake, loca
 
 	if (case_.refId) {
 		const [reference] = await sql<[{ action: CaseAction; log_message_id: Snowflake | null }?]>`
-			select log_message_id, action
+			select action, log_message_id
 			from cases
 			where guild_id = ${case_.guildId}
 				and case_id = ${case_.refId}
 		`;
 
-		if (Reflect.has(reference ?? {}, "log_message_id") && Reflect.has(reference ?? {}, "action")) {
+		if (Reflect.has(reference ?? {}, "action") && Reflect.has(reference ?? {}, "log_message_id")) {
 			msg += i18next.t("log.mod_log.case_log.case_reference", {
 				ref: hyperlink(`#${case_.refId}`, messageLink(logChannelId, reference!.log_message_id!, case_.guildId)),
 				action: caseActionLabel(reference!.action, locale),

--- a/packages/yuudachi/src/functions/logging/generateCaseLog.ts
+++ b/packages/yuudachi/src/functions/logging/generateCaseLog.ts
@@ -77,7 +77,7 @@ export async function generateCaseLog(case_: Case, logChannelId: Snowflake, loca
 		if (Reflect.has(reference ?? {}, "log_message_id") && Reflect.has(reference ?? {}, "action")) {
 			msg += i18next.t("log.mod_log.case_log.case_reference", {
 				ref: hyperlink(`#${case_.refId}`, messageLink(logChannelId, reference!.log_message_id!, case_.guildId)),
-				action: actionKeyLabel(ACTION_KEYS[reference!.action], locale),
+				action: actionKeyLabel(ACTION_KEYS[reference!.action]!, locale),
 				lng: locale,
 			});
 		}

--- a/packages/yuudachi/src/functions/logging/generateCaseLog.ts
+++ b/packages/yuudachi/src/functions/logging/generateCaseLog.ts
@@ -10,7 +10,7 @@ export async function generateCaseLog(case_: Case, logChannelId: Snowflake, loca
 	const client = container.resolve<Client<true>>(Client);
 	const sql = container.resolve<Sql<any>>(kSQL);
 
-	let action = caseActionLabel(case_.action, locale);
+	let action = caseActionLabel(case_.action, locale, true);
 
 	if ((case_.action === CaseAction.Role || case_.action === CaseAction.Unrole) && case_.roleId) {
 		try {

--- a/packages/yuudachi/src/functions/logging/generateCaseLog.ts
+++ b/packages/yuudachi/src/functions/logging/generateCaseLog.ts
@@ -2,7 +2,7 @@ import { logger, kSQL, container } from "@yuudachi/framework";
 import { Client, type Snowflake, hyperlink, time, TimestampStyles, messageLink, channelLink } from "discord.js";
 import i18next from "i18next";
 import type { Sql } from "postgres";
-import { actionKeyLabel, ACTION_KEYS } from "../../util/actionKeys.js";
+import { caseActionLabel } from "../../util/actionKeys.js";
 import { type Case, CaseAction } from "../cases/createCase.js";
 import { getGuildSetting, SettingsKeys } from "../settings/getGuildSetting.js";
 
@@ -10,7 +10,7 @@ export async function generateCaseLog(case_: Case, logChannelId: Snowflake, loca
 	const client = container.resolve<Client<true>>(Client);
 	const sql = container.resolve<Sql<any>>(kSQL);
 
-	let action = CaseAction[case_.action];
+	let action = caseActionLabel(case_.action, locale);
 
 	if ((case_.action === CaseAction.Role || case_.action === CaseAction.Unrole) && case_.roleId) {
 		try {
@@ -77,7 +77,7 @@ export async function generateCaseLog(case_: Case, logChannelId: Snowflake, loca
 		if (Reflect.has(reference ?? {}, "log_message_id") && Reflect.has(reference ?? {}, "action")) {
 			msg += i18next.t("log.mod_log.case_log.case_reference", {
 				ref: hyperlink(`#${case_.refId}`, messageLink(logChannelId, reference!.log_message_id!, case_.guildId)),
-				action: actionKeyLabel(ACTION_KEYS[reference!.action]!, locale),
+				action: caseActionLabel(reference!.action, locale),
 				lng: locale,
 			});
 		}

--- a/packages/yuudachi/src/functions/logging/generateReportLog.ts
+++ b/packages/yuudachi/src/functions/logging/generateReportLog.ts
@@ -13,7 +13,7 @@ import {
 import i18next from "i18next";
 import type { Sql } from "postgres";
 import { REPORT_REASON_MAX_LENGTH } from "../../Constants.js";
-import { actionKeyLabel, ACTION_KEYS } from "../../util/actionKeys.js";
+import { caseActionLabel } from "../../util/actionKeys.js";
 import type { CaseAction } from "../cases/createCase.js";
 import type { Report } from "../reports/createReport.js";
 import { getGuildSetting, SettingsKeys } from "../settings/getGuildSetting.js";
@@ -58,7 +58,7 @@ export async function generateReportLog(report: Report, locale: string, message?
 			parts.push(
 				i18next.t("log.report_log.case_reference", {
 					ref: hyperlink(`#${report.refId}`, messageLink(modLogChannelId, reference!.log_message_id!, report.guildId)),
-					action: actionKeyLabel(ACTION_KEYS[reference!.action]!, locale),
+					action: caseActionLabel(reference!.action, locale),
 					lng: locale,
 				}),
 			);

--- a/packages/yuudachi/src/functions/logging/generateReportLog.ts
+++ b/packages/yuudachi/src/functions/logging/generateReportLog.ts
@@ -46,7 +46,7 @@ export async function generateReportLog(report: Report, locale: string, message?
 
 	if (report.refId) {
 		const [reference] = await sql<[{ action: CaseAction; log_message_id: Snowflake | null }?]>`
-			select log_message_id, action
+			select action, log_message_id
 			from cases
 			where guild_id = ${report.guildId}
 				and case_id = ${report.refId}
@@ -54,7 +54,7 @@ export async function generateReportLog(report: Report, locale: string, message?
 
 		const modLogChannelId = await getGuildSetting(report.guildId, SettingsKeys.ModLogChannelId);
 
-		if (modLogChannelId && Reflect.has(reference ?? {}, "log_message_id") && Reflect.has(reference ?? {}, "action")) {
+		if (modLogChannelId && Reflect.has(reference ?? {}, "action") && Reflect.has(reference ?? {}, "log_message_id")) {
 			parts.push(
 				i18next.t("log.report_log.case_reference", {
 					ref: hyperlink(`#${report.refId}`, messageLink(modLogChannelId, reference!.log_message_id!, report.guildId)),

--- a/packages/yuudachi/src/util/actionKeys.ts
+++ b/packages/yuudachi/src/util/actionKeys.ts
@@ -2,10 +2,16 @@ import i18next from "i18next";
 import { CaseAction } from "../functions/cases/createCase.js";
 import { ReportStatus } from "../functions/reports/createReport.js";
 
-export function caseActionLabel(key: CaseAction, locale: string) {
+export function caseActionLabel(key: CaseAction, locale: string, isCase = false): string {
 	switch (key) {
 		case CaseAction.Role:
-			return i18next.t("log.history.cases.action_label.restriction", { lng: locale });
+			return isCase
+				? i18next.t(`log.history.cases.action_label.restriction_case`, { lng: locale })
+				: i18next.t(`log.history.cases.action_label.restriction`, { lng: locale });
+		case CaseAction.Unrole:
+			return isCase
+				? i18next.t(`log.history.cases.action_label.unrestriction_case`, { lng: locale })
+				: i18next.t(`log.history.cases.action_label.unrestriction`, { lng: locale });
 		case CaseAction.Warn:
 			return i18next.t("log.history.cases.action_label.warn", { lng: locale });
 		case CaseAction.Kick:
@@ -18,6 +24,8 @@ export function caseActionLabel(key: CaseAction, locale: string) {
 			return i18next.t("log.history.cases.action_label.unban", { lng: locale });
 		case CaseAction.Timeout:
 			return i18next.t("log.history.cases.action_label.timeout", { lng: locale });
+		case CaseAction.TimeoutEnd:
+			return i18next.t("log.history.cases.action_label.timeout_end", { lng: locale });
 		default:
 			return i18next.t("log.history.cases.action_label.unknown", { lng: locale });
 	}

--- a/packages/yuudachi/src/util/actionKeys.ts
+++ b/packages/yuudachi/src/util/actionKeys.ts
@@ -6,12 +6,12 @@ export function caseActionLabel(key: CaseAction, locale: string, isCase = false)
 	switch (key) {
 		case CaseAction.Role:
 			return isCase
-				? i18next.t(`log.history.cases.action_label.restriction_case`, { lng: locale })
-				: i18next.t(`log.history.cases.action_label.restriction`, { lng: locale });
+				? i18next.t("log.history.cases.action_label.restriction_case", { lng: locale })
+				: i18next.t("log.history.cases.action_label.restriction", { lng: locale });
 		case CaseAction.Unrole:
 			return isCase
-				? i18next.t(`log.history.cases.action_label.unrestriction_case`, { lng: locale })
-				: i18next.t(`log.history.cases.action_label.unrestriction`, { lng: locale });
+				? i18next.t("log.history.cases.action_label.unrestriction_case", { lng: locale })
+				: i18next.t("log.history.cases.action_label.unrestriction", { lng: locale });
 		case CaseAction.Warn:
 			return i18next.t("log.history.cases.action_label.warn", { lng: locale });
 		case CaseAction.Kick:

--- a/packages/yuudachi/src/util/actionKeys.ts
+++ b/packages/yuudachi/src/util/actionKeys.ts
@@ -1,38 +1,37 @@
 import i18next from "i18next";
+import { CaseAction } from "../functions/cases/createCase.js";
+import { ReportStatus } from "../functions/reports/createReport.js";
 
-export const ACTION_KEYS = ["restriction", "", "warn", "kick", "softban", "ban", "unban", "timeout", ""] as const;
-export const REPORT_KEYS = ["pending", "approved", "rejected", "spam"] as const;
-
-export function actionKeyLabel(key: typeof ACTION_KEYS[number], locale: string) {
+export function caseActionLabel(key: CaseAction, locale: string) {
 	switch (key) {
-		case "restriction":
+		case CaseAction.Role:
 			return i18next.t("log.history.cases.action_label.restriction", { lng: locale });
-		case "warn":
+		case CaseAction.Warn:
 			return i18next.t("log.history.cases.action_label.warn", { lng: locale });
-		case "kick":
+		case CaseAction.Kick:
 			return i18next.t("log.history.cases.action_label.kick", { lng: locale });
-		case "softban":
+		case CaseAction.Softban:
 			return i18next.t("log.history.cases.action_label.softban", { lng: locale });
-		case "ban":
+		case CaseAction.Ban:
 			return i18next.t("log.history.cases.action_label.ban", { lng: locale });
-		case "unban":
+		case CaseAction.Unban:
 			return i18next.t("log.history.cases.action_label.unban", { lng: locale });
-		case "timeout":
+		case CaseAction.Timeout:
 			return i18next.t("log.history.cases.action_label.timeout", { lng: locale });
 		default:
 			return i18next.t("log.history.cases.action_label.unknown", { lng: locale });
 	}
 }
 
-export function reportKeyLabel(key: typeof REPORT_KEYS[number], locale: string) {
+export function reportStatusLabel(key: ReportStatus, locale: string) {
 	switch (key) {
-		case "pending":
+		case ReportStatus.Pending:
 			return i18next.t("log.history.reports.status_label.pending", { lng: locale });
-		case "approved":
+		case ReportStatus.Approved:
 			return i18next.t("log.history.reports.status_label.approved", { lng: locale });
-		case "rejected":
+		case ReportStatus.Rejected:
 			return i18next.t("log.history.reports.status_label.rejected", { lng: locale });
-		case "spam":
+		case ReportStatus.Spam:
 			return i18next.t("log.history.reports.status_label.spam", { lng: locale });
 		default:
 			return i18next.t("log.history.reports.status_label.unknown", { lng: locale });

--- a/packages/yuudachi/src/util/actionKeys.ts
+++ b/packages/yuudachi/src/util/actionKeys.ts
@@ -1,2 +1,40 @@
+import i18next from "i18next";
+
 export const ACTION_KEYS = ["restriction", "", "warn", "kick", "softban", "ban", "unban", "timeout", ""] as const;
 export const REPORT_KEYS = ["pending", "approved", "rejected", "spam"] as const;
+
+export function actionKeyLabel(key: typeof ACTION_KEYS[number], locale: string) {
+	switch (key) {
+		case "restriction":
+			return i18next.t("log.history.cases.action_label.restriction", { lng: locale });
+		case "warn":
+			return i18next.t("log.history.cases.action_label.warn", { lng: locale });
+		case "kick":
+			return i18next.t("log.history.cases.action_label.kick", { lng: locale });
+		case "softban":
+			return i18next.t("log.history.cases.action_label.softban", { lng: locale });
+		case "ban":
+			return i18next.t("log.history.cases.action_label.ban", { lng: locale });
+		case "unban":
+			return i18next.t("log.history.cases.action_label.unban", { lng: locale });
+		case "timeout":
+			return i18next.t("log.history.cases.action_label.timeout", { lng: locale });
+		default:
+			return i18next.t("log.history.cases.action_label.unknown", { lng: locale });
+	}
+}
+
+export function reportKeyLabel(key: typeof REPORT_KEYS[number], locale: string) {
+	switch (key) {
+		case "pending":
+			return i18next.t("log.history.reports.status_label.pending", { lng: locale });
+		case "approved":
+			return i18next.t("log.history.reports.status_label.approved", { lng: locale });
+		case "rejected":
+			return i18next.t("log.history.reports.status_label.rejected", { lng: locale });
+		case "spam":
+			return i18next.t("log.history.reports.status_label.spam", { lng: locale });
+		default:
+			return i18next.t("log.history.reports.status_label.unknown", { lng: locale });
+	}
+}

--- a/packages/yuudachi/src/util/generateHistory.ts
+++ b/packages/yuudachi/src/util/generateHistory.ts
@@ -19,11 +19,12 @@ import {
 import i18next from "i18next";
 import type { Sql } from "postgres";
 import { Color, HISTORY_DESCRIPTION_MAX_LENGTH, ThreatLevelColor } from "../Constants.js";
+import { CaseAction } from "../functions/cases/createCase.js";
 import type { RawCase } from "../functions/cases/transformCase.js";
 import { ReportStatus } from "../functions/reports/createReport.js";
 import type { RawReport } from "../functions/reports/transformReport.js";
 import { getGuildSetting, SettingsKeys } from "../functions/settings/getGuildSetting.js";
-import { actionKeyLabel, ACTION_KEYS, reportKeyLabel, REPORT_KEYS } from "./actionKeys.js";
+import { caseActionLabel, reportStatusLabel } from "./actionKeys.js";
 
 dayjs.extend(relativeTime);
 
@@ -165,19 +166,19 @@ export async function generateCaseHistory(
 	`;
 
 	const caseCounter = cases.reduce((count: CaseFooter, case_) => {
-		const action = ACTION_KEYS[case_.action]!;
+		const action = case_.action!;
 		count[action] = (count[action] ?? 0) + 1;
 		return count;
 	}, {});
 
 	const values: [number, number, number, number, number, number, number] = [
-		caseCounter.unban ?? 0,
-		caseCounter.warn ?? 0,
-		caseCounter.restriction ?? 0,
-		caseCounter.kick ?? 0,
-		caseCounter.softban ?? 0,
-		caseCounter.ban ?? 0,
-		caseCounter.timeout ?? 0,
+		caseCounter[CaseAction.Role] ?? 0,
+		caseCounter[CaseAction.Warn] ?? 0,
+		caseCounter[CaseAction.Kick] ?? 0,
+		caseCounter[CaseAction.Softban] ?? 0,
+		caseCounter[CaseAction.Ban] ?? 0,
+		caseCounter[CaseAction.Unban] ?? 0,
+		caseCounter[CaseAction.Timeout] ?? 0,
 	];
 	const colorIndex = Math.min(
 		values.reduce((a, b) => a + b),
@@ -191,7 +192,7 @@ export async function generateCaseHistory(
 			identifierURL: case_.log_message_id
 				? messageLink(moduleLogChannelId, case_.log_message_id, case_.guild_id)
 				: undefined,
-			label: actionKeyLabel(ACTION_KEYS[case_.action]!, locale),
+			label: caseActionLabel(case_.action, locale).toUpperCase(),
 			description: case_.reason ?? undefined,
 		};
 	});
@@ -274,7 +275,7 @@ export async function generateReportHistory(
 			created: report.created_at,
 			identifierLabel: `#${report.report_id} (${userRoleString})`,
 			identifierURL: report.log_post_id ? channelLink(report.log_post_id, report.guild_id) : undefined,
-			label: reportKeyLabel(REPORT_KEYS[report.status]!, locale),
+			label: reportStatusLabel(report.status, locale).toUpperCase(),
 			description: report.reason ?? undefined,
 		};
 	});

--- a/packages/yuudachi/src/util/generateHistory.ts
+++ b/packages/yuudachi/src/util/generateHistory.ts
@@ -23,7 +23,7 @@ import type { RawCase } from "../functions/cases/transformCase.js";
 import { ReportStatus } from "../functions/reports/createReport.js";
 import type { RawReport } from "../functions/reports/transformReport.js";
 import { getGuildSetting, SettingsKeys } from "../functions/settings/getGuildSetting.js";
-import { ACTION_KEYS, REPORT_KEYS } from "./actionKeys.js";
+import { actionKeyLabel, ACTION_KEYS, reportKeyLabel, REPORT_KEYS } from "./actionKeys.js";
 
 dayjs.extend(relativeTime);
 
@@ -103,27 +103,6 @@ function generateHistoryEmbed(
 			text: footerText,
 		},
 	};
-}
-
-function actionKeyLabel(key: typeof ACTION_KEYS[number], locale: string) {
-	switch (key) {
-		case "restriction":
-			return i18next.t("log.history.cases.action_label.restriction", { lng: locale });
-		case "warn":
-			return i18next.t("log.history.cases.action_label.warn", { lng: locale });
-		case "kick":
-			return i18next.t("log.history.cases.action_label.kick", { lng: locale });
-		case "softban":
-			return i18next.t("log.history.cases.action_label.softban", { lng: locale });
-		case "ban":
-			return i18next.t("log.history.cases.action_label.ban", { lng: locale });
-		case "unban":
-			return i18next.t("log.history.cases.action_label.unban", { lng: locale });
-		case "timeout":
-			return i18next.t("log.history.cases.action_label.timeout", { lng: locale });
-		default:
-			return i18next.t("log.history.cases.action_label.unknown", { lng: locale });
-	}
 }
 
 function actionSummary(
@@ -225,21 +204,6 @@ export async function generateCaseHistory(
 		actionSummary(...values, locale),
 		locale,
 	);
-}
-
-function reportKeyLabel(key: typeof REPORT_KEYS[number], locale: string) {
-	switch (key) {
-		case "pending":
-			return i18next.t("log.history.reports.status_label.pending", { lng: locale });
-		case "approved":
-			return i18next.t("log.history.reports.status_label.approved", { lng: locale });
-		case "rejected":
-			return i18next.t("log.history.reports.status_label.rejected", { lng: locale });
-		case "spam":
-			return i18next.t("log.history.reports.status_label.spam", { lng: locale });
-		default:
-			return i18next.t("log.history.reports.status_label.unknown", { lng: locale });
-	}
 }
 
 function reportSummary(reported: number, authored: number, spam: number, locale: string) {


### PR DESCRIPTION
## Why?

- Add labels to case references, it's hard to know what the case referenced did without going to it, which is a pain to do repeatedly
- Refactor case system to use translations on all actions

> **Note**
>This closes #1137

<details><summary>Examples</summary>
Case log:

![image](https://user-images.githubusercontent.com/67063134/196302753-06c52f1a-fe5b-4d6e-b5cf-cd4dda5a6b97.png)

Reports:

![image](https://user-images.githubusercontent.com/67063134/196302772-1fae9b18-3fd3-4ac9-97d8-8e1d3f7ca2ee.png)

</details>