### PR TITLE
chore(case*): fix timestamp and add goto button

### DIFF
--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -68,6 +68,9 @@
 				"autocomplete": {
 					"no_reason": "No reason",
 					"show_history": "Show history for user {{- user}}"
+				},
+				"buttons": {
+					"goto": "Go to case {{- case}}"
 				}
 			},
 			"reports": {

--- a/packages/yuudachi/src/commands/moderation/case.ts
+++ b/packages/yuudachi/src/commands/moderation/case.ts
@@ -7,9 +7,11 @@ import {
 	truncateEmbed,
 	AUTOCOMPLETE_CHOICE_LIMIT,
 	AUTOCOMPLETE_CHOICE_NAME_LENGTH_LIMIT,
+	createButton,
+	createMessageActionRow,
 } from "@yuudachi/framework";
 import type { ArgsParam, InteractionParam, LocaleParam, CommandMethod } from "@yuudachi/framework/types";
-import { Collection, type Snowflake } from "discord.js";
+import { ButtonStyle, Collection, messageLink, type Snowflake } from "discord.js";
 import i18next from "i18next";
 import type { Sql } from "postgres";
 import { OP_DELIMITER } from "../../Constants.js";
@@ -122,12 +124,23 @@ export default class extends Command<typeof CaseLookupCommand> {
 			);
 			const moderator = await interaction.client.users.fetch(modCase.mod_id);
 
+			const gotoButton = createButton({
+				label: i18next.t("command.mod.case.buttons.goto", {
+					case: modCase.case_id,
+					lng: locale,
+				}),
+				style: ButtonStyle.Link,
+				disabled: !modLogChannel?.id || !modCase.log_message_id,
+				url: messageLink(modLogChannel!.id, modCase.log_message_id!, interaction.guildId),
+			});
+
 			await interaction.editReply({
 				embeds: [
 					truncateEmbed(
 						await generateCaseEmbed(interaction.guildId, modLogChannel!.id, moderator, transformCase(modCase)),
 					),
 				],
+				components: [createMessageActionRow([gotoButton])],
 			});
 			return;
 		}

--- a/packages/yuudachi/src/functions/logging/generateCaseEmbed.ts
+++ b/packages/yuudachi/src/functions/logging/generateCaseEmbed.ts
@@ -20,7 +20,7 @@ export async function generateCaseEmbed(
 		footer: {
 			text: i18next.t("log.mod_log.case_log.footer", { case_id: case_.caseId, lng: locale }),
 		},
-		timestamp: new Date().toISOString(),
+		timestamp: new Date(case_.createdAt).toISOString(),
 	});
 
 	if (user) {


### PR DESCRIPTION
## Why?

This PR has effect on:
- Closes #1142 (Fixed by setting the `createdAt` field in the timestamp)
- Closes #1143 (Cases now have a button, see in `examples`)
- Bug found in testing, editing a case replaces the created timestamp (If this isn't a bug this PR would require a DB migration to implement this feature properly)

<details><summary>Examples</summary>
Case button example:

![image](https://user-images.githubusercontent.com/67063134/196065335-e577b882-f2de-4211-8b82-7be2527420e0.png)
</details>