### PR TITLE
chore(resolve-message/repost): allow repost be used from any channel

### DIFF
--- a/packages/yuudachi/src/commands/utility/repost.ts
+++ b/packages/yuudachi/src/commands/utility/repost.ts
@@ -34,7 +34,7 @@ export default class extends Command<typeof RepostCommand | typeof RepostMessage
 		}
 
 		const { guildId, channelId, messageId } = parsedLink;
-		const message = await resolveMessage(interaction.channelId, guildId!, channelId!, messageId!, locale);
+		const message = await resolveMessage(interaction.channelId, guildId!, channelId!, messageId!, locale, true);
 
 		await this.handle(interaction, message, locale);
 	}

--- a/packages/yuudachi/src/util/resolveMessage.ts
+++ b/packages/yuudachi/src/util/resolveMessage.ts
@@ -22,6 +22,7 @@ export async function resolveMessage(
 	channelId: Snowflake,
 	messageId: Snowflake,
 	locale: string,
+	unsafe = false,
 ) {
 	const client = container.resolve<Client<true>>(Client);
 
@@ -51,6 +52,7 @@ export async function resolveMessage(
 	const ignoreChannels = await getGuildSetting(guild.id, SettingsKeys.LogIgnoreChannels);
 
 	if (
+		!unsafe &&
 		originChannelId !== channel.id &&
 		(ignoreChannels.includes(channel.id) ||
 			(channel.parentId && ignoreChannels.includes(channel.parentId)) ||


### PR DESCRIPTION
## Why?
The repost is a utility/fun command, allowing it to be used from anywhere in the server is nice!
> This closes #1140 