### PR TITLE
feat(yuudachi): use message link buttons instead of embed author url

### DIFF
--- a/packages/yuudachi/locales/en-US/translation.json
+++ b/packages/yuudachi/locales/en-US/translation.json
@@ -26,7 +26,8 @@
 				"ignored_channel": "Resolving a message from an ignored channel is not allowed."
 			},
 			"buttons": {
-				"cancel": "Cancel"
+				"cancel": "Cancel",
+				"message_reference": "Original message"
 			}
 		},
 		"config": {

--- a/packages/yuudachi/src/commands/moderation/clear.ts
+++ b/packages/yuudachi/src/commands/moderation/clear.ts
@@ -12,7 +12,14 @@ import {
 } from "@yuudachi/framework";
 import type { ArgsParam, InteractionParam, LocaleParam, CommandMethod } from "@yuudachi/framework/types";
 import dayjs from "dayjs";
-import { type APIEmbed, ButtonStyle, ComponentType, type Webhook, type Message } from "discord.js";
+import {
+	type APIEmbed,
+	ButtonStyle,
+	ComponentType,
+	type Webhook,
+	type Message,
+	type APIButtonComponent,
+} from "discord.js";
 import i18next from "i18next";
 import { nanoid } from "nanoid";
 import { inject, injectable } from "tsyringe";
@@ -22,6 +29,7 @@ import { formatMessagesToAttachment } from "../../functions/logging/formatMessag
 import { fetchMessages, orderMessages, pruneMessages } from "../../functions/pruning/pruneMessages.js";
 import { getGuildSetting, SettingsKeys } from "../../functions/settings/getGuildSetting.js";
 import type { ClearCommand, ClearContextCommand } from "../../interactions/index.js";
+import { createMessageLinkButton } from "../../util/createMessageLinkButton.js";
 import { parseMessageLink, resolveMessage } from "../../util/resolveMessage.js";
 
 async function resolveSnowflakeOrLink(
@@ -111,9 +119,11 @@ export default class extends Command<typeof ClearCommand | typeof ClearContextCo
 		];
 
 		const embeds: APIEmbed[] = [];
+		const buttons: APIButtonComponent[] = [cancelButton, clearButton];
 
 		if (!messages.has(oldest.id)) {
 			embeds.push(formatMessageToEmbed(earliest as Message<true>, locale));
+			buttons.push(createMessageLinkButton(earliest as Message<true>, locale));
 			confirmParts.push(
 				i18next.t("command.mod.clear.message_too_old", {
 					embeds,
@@ -125,7 +135,7 @@ export default class extends Command<typeof ClearCommand | typeof ClearContextCo
 
 		await interaction.editReply({
 			content: confirmParts.join("\n"),
-			components: [createMessageActionRow([cancelButton, clearButton])],
+			components: [createMessageActionRow(buttons)],
 			embeds,
 		});
 

--- a/packages/yuudachi/src/commands/moderation/sub/report/message.ts
+++ b/packages/yuudachi/src/commands/moderation/sub/report/message.ts
@@ -13,6 +13,7 @@ import { formatMessageToEmbed } from "../../../../functions/logging/formatMessag
 import { upsertReportLog } from "../../../../functions/logging/upsertReportLog.js";
 import { createReport, ReportType } from "../../../../functions/reports/createReport.js";
 import type { ReportCommand } from "../../../../interactions/index.js";
+import { createMessageLinkButton } from "../../../../util/createMessageLinkButton.js";
 import { localeTrustAndSafety } from "../../../../util/localizeTrustAndSafety.js";
 
 type MessageReportArgs = Omit<ArgsParam<typeof ReportCommand>["message"], "message_link"> & {
@@ -69,7 +70,14 @@ export async function message(
 	const reply = await interaction.editReply({
 		content: contentParts.join("\n"),
 		embeds: [formatMessageToEmbed(args.message as Message<true>, locale)],
-		components: [createMessageActionRow([cancelButton, reportButton, trustAndSafetyButton])],
+		components: [
+			createMessageActionRow([
+				cancelButton,
+				reportButton,
+				trustAndSafetyButton,
+				createMessageLinkButton(args.message as Message<true>, locale),
+			]),
+		],
 	});
 
 	const collectedInteraction = await reply

--- a/packages/yuudachi/src/commands/moderation/sub/reports/lookup.ts
+++ b/packages/yuudachi/src/commands/moderation/sub/reports/lookup.ts
@@ -1,4 +1,4 @@
-import { kSQL, truncateEmbed, container } from "@yuudachi/framework";
+import { kSQL, truncateEmbed, container, createMessageActionRow } from "@yuudachi/framework";
 import type { ArgsParam, InteractionParam, LocaleParam } from "@yuudachi/framework/types";
 import type { Message } from "discord.js";
 import i18next from "i18next";
@@ -9,6 +9,7 @@ import { generateReportEmbed } from "../../../../functions/logging/generateRepor
 import { ReportType } from "../../../../functions/reports/createReport.js";
 import { type RawReport, transformReport } from "../../../../functions/reports/transformReport.js";
 import type { ReportUtilsCommand } from "../../../../interactions/index.js";
+import { createMessageLinkButton } from "../../../../util/createMessageLinkButton.js";
 import { generateHistory, generateUserInfo, HistoryType } from "../../../../util/generateHistory.js";
 import { resolveMemberAndUser } from "../../../../util/resolveMemberAndUser.js";
 import { resolveMessage } from "../../../../util/resolveMessage.js";
@@ -67,6 +68,7 @@ export async function lookup(
 
 		await interaction.editReply({
 			embeds,
+			components: message ? [createMessageActionRow([createMessageLinkButton(message, locale)])] : [],
 		});
 		return;
 	}

--- a/packages/yuudachi/src/commands/utility/repost.ts
+++ b/packages/yuudachi/src/commands/utility/repost.ts
@@ -1,9 +1,10 @@
-import { Command } from "@yuudachi/framework";
+import { Command, createMessageActionRow } from "@yuudachi/framework";
 import type { ArgsParam, InteractionParam, LocaleParam, CommandMethod } from "@yuudachi/framework/types";
 import type { Message } from "discord.js";
 import i18next from "i18next";
 import { formatMessageToEmbed } from "../../functions/logging/formatMessageToEmbed.js";
 import type { RepostCommand, RepostMessageContextCommand } from "../../interactions/index.js";
+import { createMessageLinkButton } from "../../util/createMessageLinkButton.js";
 import { parseMessageLink, resolveMessage } from "../../util/resolveMessage.js";
 
 export default class extends Command<typeof RepostCommand | typeof RepostMessageContextCommand> {
@@ -12,7 +13,10 @@ export default class extends Command<typeof RepostCommand | typeof RepostMessage
 		message: Message<true>,
 		locale: string,
 	) {
-		await interaction.editReply({ embeds: [formatMessageToEmbed(message, locale)] });
+		await interaction.editReply({
+			embeds: [formatMessageToEmbed(message, locale)],
+			components: [createMessageActionRow([createMessageLinkButton(message, locale)])],
+		});
 	}
 
 	public override async chatInput(

--- a/packages/yuudachi/src/functions/logging/formatMessageToEmbed.ts
+++ b/packages/yuudachi/src/functions/logging/formatMessageToEmbed.ts
@@ -7,7 +7,6 @@ export function formatMessageToEmbed(message: Message<true>, locale: string) {
 	let embed = truncateEmbed({
 		author: {
 			name: `${message.author.tag} (${message.author.id})`,
-			url: message.url,
 			icon_url: message.author.displayAvatarURL(),
 		},
 		description: message.content.length

--- a/packages/yuudachi/src/functions/logging/upsertReportLog.ts
+++ b/packages/yuudachi/src/functions/logging/upsertReportLog.ts
@@ -1,9 +1,10 @@
 import { Buffer } from "node:buffer";
-import { kSQL, container } from "@yuudachi/framework";
+import { kSQL, container, createMessageActionRow } from "@yuudachi/framework";
 import type { APIEmbed, Embed, Guild, Message } from "discord.js";
 import i18next from "i18next";
 import type { Sql } from "postgres";
 import { REPORT_MESSAGE_CONTEXT_LIMIT } from "../../Constants.js";
+import { createMessageLinkButton } from "../../util/createMessageLinkButton.js";
 import { generateUserInfo } from "../../util/generateHistory.js";
 import { resolveMemberAndUser } from "../../util/resolveMemberAndUser.js";
 import { resolveMessage } from "../../util/resolveMessage.js";
@@ -61,6 +62,9 @@ export async function upsertReportLog(guild: Guild, report: Report, message?: Me
 				lng: locale,
 			}),
 			message: {
+				components: localMessage?.inGuild
+					? [createMessageActionRow([createMessageLinkButton(localMessage as Message<true>, locale)])]
+					: [],
 				embeds,
 				files:
 					messageContext && localMessage

--- a/packages/yuudachi/src/util/createMessageLinkButton.ts
+++ b/packages/yuudachi/src/util/createMessageLinkButton.ts
@@ -1,0 +1,11 @@
+import { createButton } from "@yuudachi/framework";
+import { type Message, ButtonStyle } from "discord.js";
+import i18next from "i18next";
+
+export function createMessageLinkButton(message: Message<true>, locale: string) {
+	return createButton({
+		style: ButtonStyle.Link,
+		url: message.url,
+		label: i18next.t("command.common.buttons.message_reference", { lng: locale }),
+	});
+}


### PR DESCRIPTION
The message author link has no visuals that indicate it is a link and does not work on some mobile versions of Discord. Additionally, the semantics of associating a user name click to lead to a message link is unclear.

This PR resolves this UX issue by removing the embed author link in favor of a message component link button in all instances, where a message is resolved to an embed to display to a user.