### PR TITLE
feat(reports): ability to disable reports server wide

### DIFF
--- a/apps/yuudachi/locales/en-US/translation.json
+++ b/apps/yuudachi/locales/en-US/translation.json
@@ -79,6 +79,26 @@
 					"no_reason": "No reason",
 					"show_history_target": "Show history for target {{- user}}",
 					"show_history_author": "Show history for author {{- user}}"
+				},
+				"toggle": {
+					"buttons": {
+						"toggle": {
+							"enable": "Enable reports",
+							"disable": "Disable reports"
+						}
+					},
+					"pending": {
+						"enable": "Do you really want to enable reports guild wide?",
+						"disable": "Do you really want to disable reports guild wide?"
+					},
+					"success": {
+						"enable": "Successfully enabled reports guild wide.",
+						"disable": "Successfully disabled reports guild wide."
+					},
+					"cancel": {
+						"enable": "Canceled enabling reports guild wide.",
+						"disable": "Canceled disabling reports guild wide."
+					}
 				}
 			},
 			"warn": {

--- a/apps/yuudachi/locales/en-US/translation.json
+++ b/apps/yuudachi/locales/en-US/translation.json
@@ -378,7 +378,8 @@
 						"invalid_attachment": "Invalid attachment, only images are allowed.",
 						"timed_out": "The report has timed out, please try again.",
 						"bot": "You cannot report bots.",
-						"no_attachment_forward": "This user has already been recently reported, you must specify an attachment to forward if it helps the context of the report."
+						"no_attachment_forward": "This user has already been recently reported, you must specify an attachment to forward if it helps the context of the report.",
+						"disabled": "The creation of reports has been disabled by the server moderators."
 					},
 					"warnings": "**Attention:** We are not Discord and we **cannot** moderate {{- trust_and_safety}} issues.\n**Creating false reports may lead to moderation actions.**",
 					"trust_and_safety_sub": "Trust & Safety",

--- a/apps/yuudachi/migrations/1673411947-report-toggle.js
+++ b/apps/yuudachi/migrations/1673411947-report-toggle.js
@@ -1,0 +1,11 @@
+/**
+ * @param {import('postgres').Sql} sql
+ */
+export async function up(sql) {
+	await sql.unsafe(`
+		alter table guild_settings
+			add enable_reports boolean not null default true;
+
+		comment on column reports.context_messages_ids is 'The ids of the messages that were used add context to the report.'
+	`);
+}

--- a/apps/yuudachi/src/commands/moderation/report.ts
+++ b/apps/yuudachi/src/commands/moderation/report.ts
@@ -248,6 +248,10 @@ export default class extends Command<
 			throw new Error(i18next.t("command.mod.report.common.errors.no_self", { lng: locale }));
 		}
 
+		if (!(await getGuildSetting(author.guild.id, SettingsKeys.EnableReports))) {
+			throw new Error(i18next.t("command.mod.report.common.errors.disabled", { lng: locale }));
+		}
+
 		const userKey = `guild:${author.guild.id}:report:user:${target.id}`;
 		const latestReport = await getPendingReportByTarget(author.guild.id, target.id);
 		if (latestReport || (await this.redis.exists(userKey))) {

--- a/apps/yuudachi/src/commands/moderation/reports.ts
+++ b/apps/yuudachi/src/commands/moderation/reports.ts
@@ -4,6 +4,7 @@ import { handleReportAutocomplete } from "../../functions/autocomplete/reports.j
 import type { ReportUtilsCommand } from "../../interactions/index.js";
 import { lookup } from "./sub/reports/lookup.js";
 import { status } from "./sub/reports/status.js";
+import { toggle } from "./sub/reports/toggle.js";
 
 export default class extends Command<typeof ReportUtilsCommand> {
 	public override async autocomplete(
@@ -20,7 +21,7 @@ export default class extends Command<typeof ReportUtilsCommand> {
 		locale: LocaleParam,
 	): Promise<void> {
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		await interaction.deferReply({ ephemeral: args.lookup?.hide ?? true });
+		const reply = await interaction.deferReply({ ephemeral: args.lookup?.hide ?? true });
 
 		switch (Object.keys(args)[0]) {
 			case "lookup":
@@ -28,6 +29,9 @@ export default class extends Command<typeof ReportUtilsCommand> {
 				break;
 			case "status":
 				await status(interaction, args.status, locale);
+				break;
+			case "toggle":
+				await toggle(interaction, reply, locale);
 				break;
 			default:
 		}

--- a/apps/yuudachi/src/commands/moderation/sub/reports/toggle.ts
+++ b/apps/yuudachi/src/commands/moderation/sub/reports/toggle.ts
@@ -1,0 +1,82 @@
+import { createButton, createMessageActionRow, logger } from "@yuudachi/framework";
+import type { InteractionParam, LocaleParam } from "@yuudachi/framework/types";
+import type { InteractionResponse } from "discord.js";
+import { ButtonStyle, ComponentType } from "discord.js";
+import i18next from "i18next";
+import { nanoid } from "nanoid";
+import { checkLogChannel } from "../../../../functions/settings/checkLogChannel.js";
+import { getGuildSetting, SettingsKeys } from "../../../../functions/settings/getGuildSetting.js";
+import { updateGuildSetting } from "../../../../functions/settings/updateGuildSetting.js";
+
+export async function toggle(
+	interaction: InteractionParam,
+	reply: InteractionResponse<true>,
+	locale: LocaleParam,
+): Promise<void> {
+	const reportLogChannel = checkLogChannel(
+		interaction.guild,
+		await getGuildSetting(interaction.guildId, SettingsKeys.ReportChannelId),
+	);
+
+	if (!reportLogChannel) {
+		throw new Error(i18next.t("common.errors.no_report_channel", { lng: locale }));
+	}
+
+	const status = await getGuildSetting<boolean>(interaction.guildId, SettingsKeys.EnableReports);
+	const suffix = status ? "disable" : "enable";
+
+	const toggleKey = nanoid();
+	const cancelKey = nanoid();
+
+	const toggleButton = createButton({
+		label: i18next.t(`command.mod.reports.toggle.buttons.toggle.${suffix}`, { lng: locale }),
+		customId: toggleKey,
+		style: status ? ButtonStyle.Danger : ButtonStyle.Success,
+	});
+	const cancelButton = createButton({
+		label: i18next.t("command.common.buttons.cancel", { lng: locale }),
+		customId: cancelKey,
+		style: ButtonStyle.Secondary,
+	});
+
+	await interaction.editReply({
+		content: i18next.t(`command.mod.reports.toggle.pending.${suffix}`, { lng: locale }),
+		components: [createMessageActionRow([cancelButton, toggleButton])],
+	});
+
+	const collectedInteraction = await reply
+		.awaitMessageComponent({
+			filter: (collected) => collected.user.id === interaction.user.id,
+			componentType: ComponentType.Button,
+			time: 15_000,
+		})
+		.catch(async () => {
+			try {
+				await interaction.editReply({
+					content: i18next.t("command.common.errors.timed_out", { lng: locale }),
+					components: [],
+				});
+			} catch (error_) {
+				const error = error_ as Error;
+				logger.error(error, error.message);
+			}
+
+			return undefined;
+		});
+
+	if (collectedInteraction?.customId === cancelKey) {
+		await collectedInteraction.update({
+			content: i18next.t(`command.mod.reports.toggle.cancel.${suffix}`, { lng: locale }),
+			components: [],
+		});
+	} else if (collectedInteraction?.customId === toggleKey) {
+		await collectedInteraction.deferUpdate();
+
+		await updateGuildSetting(interaction.guildId, SettingsKeys.EnableReports, !status);
+
+		await collectedInteraction.editReply({
+			content: i18next.t(`command.mod.reports.toggle.success.${suffix}`, { lng: locale }),
+			components: [],
+		});
+	}
+}

--- a/apps/yuudachi/src/functions/settings/getGuildSetting.ts
+++ b/apps/yuudachi/src/functions/settings/getGuildSetting.ts
@@ -7,6 +7,7 @@ export enum SettingsKeys {
 	AutomodIgnoreRoles = "automod_ignore_roles",
 	EmbedRoleId = "embed_role_id",
 	EmojiRoleId = "emoji_role_id",
+	EnableReports = "enable_reports",
 	ForceLocale = "force_locale",
 	GuildLogWebhookId = "guild_log_webhook_id",
 	Locale = "locale",

--- a/apps/yuudachi/src/functions/settings/updateGuildSetting.ts
+++ b/apps/yuudachi/src/functions/settings/updateGuildSetting.ts
@@ -1,0 +1,22 @@
+import { kSQL } from "@yuudachi/framework";
+import type { Snowflake } from "discord.js";
+import type { SerializableParameter, Sql } from "postgres";
+import { container } from "tsyringe";
+import type { SettingsKeys, ReportStatusTagTuple, ReportTypeTagTuple } from "./getGuildSetting.js";
+
+export async function updateGuildSetting<T = string>(
+	guildId: Snowflake,
+	prop: SettingsKeys,
+	newValue: T,
+	table = "guild_settings",
+) {
+	const sql = container.resolve<Sql<{}>>(kSQL);
+
+	const [data] = await sql.unsafe<[{ value: ReportStatusTagTuple | ReportTypeTagTuple | boolean | string | null }?]>(
+		`update ${table} set ${prop} = $2
+		where guild_id = $1`,
+		[guildId, newValue] as SerializableParameter[],
+	);
+
+	return (data?.value ?? null) as unknown as T;
+}

--- a/apps/yuudachi/src/interactions/moderation/reports.ts
+++ b/apps/yuudachi/src/interactions/moderation/reports.ts
@@ -49,6 +49,11 @@ export const ReportUtilsCommand = {
 				},
 			],
 		},
+		{
+			name: "toggle",
+			description: "Toggle the reports creation guild wide",
+			type: ApplicationCommandOptionType.Subcommand,
+		},
 	],
 	default_member_permissions: "0",
 } as const;


### PR DESCRIPTION
This PR adds a sub-command to the reports command with the ability to disable reports server-wide

> **Note**
> This PR requires a command redeploy
> This PR requires a migration under `1673411947-report-toggle.js`