### PR TITLE
chore(forwardReport): use consistent message style

### DIFF
--- a/apps/yuudachi/locales/en-US/translation.json
+++ b/apps/yuudachi/locales/en-US/translation.json
@@ -647,8 +647,8 @@
 			"updated_at": "**Updated at:** {{- updated_at}}",
 			"footer": "Hint: To resolve a report: Change the status forum label, reference it in a case, set the reference for an existing case with /reference, or set the status via /reports status",
 			"forward": {
-				"message": "**Message report forwarded**\n • Author: {{- author}}\n • Reason: {{- reason}}",
-				"user": "**Attachment forwarded**\n • Author: {{- author}}\n • Reason: {{- reason}}",
+				"message": "Message report forwarded",
+				"user": "Attachment forwarded",
 				"errors": {
 					"generic": "There was an error forwarding the report.",
 					"no_thread": "There was an error forwarding the report the associated thread could not be found."

--- a/apps/yuudachi/src/functions/logging/forwardReport.ts
+++ b/apps/yuudachi/src/functions/logging/forwardReport.ts
@@ -1,6 +1,6 @@
 import { createMessageActionRow } from "@yuudachi/framework";
 import type { APIEmbed, Attachment, AttachmentPayload, Guild, User } from "discord.js";
-import { inlineCode, userMention, Message } from "discord.js";
+import { codeBlock, Message } from "discord.js";
 import i18next from "i18next";
 import { Color } from "../../Constants.js";
 import { createMessageLinkButton } from "../../util/createMessageLinkButton.js";
@@ -35,8 +35,26 @@ export async function forwardReport(
 		throw new Error(i18next.t("log.report_log.forward.errors.no_thread", { lng: locale }));
 	}
 
-	const embeds: APIEmbed[] = [];
 	const isMessage = payload instanceof Message;
+	const embeds: APIEmbed[] = [
+		{
+			author: {
+				name: `${author.tag} (${author.id})`,
+				icon_url: author.displayAvatarURL(),
+			},
+			description: i18next.t("log.report_log.reason", {
+				reason: codeBlock(reason),
+				lng: locale,
+			}),
+			footer: {
+				text: i18next.t(`log.report_log.forward.${isMessage ? "message" : "user"}`, {
+					lng: locale,
+				}),
+			},
+			timestamp: new Date().toISOString(),
+			color: Color.DiscordPrimary,
+		},
+	];
 
 	if (isMessage) {
 		await updateReport({
@@ -56,11 +74,6 @@ export async function forwardReport(
 	}
 
 	await thread.send({
-		content: i18next.t(`log.report_log.forward.${isMessage ? "message" : "user"}`, {
-			author: `${userMention(author.id)} - \`${author.tag}\` (${author.id})`,
-			reason: inlineCode(reason),
-			lng: locale,
-		}),
 		embeds,
 		components: isMessage ? [createMessageActionRow([createMessageLinkButton(payload as Message<true>, locale)])] : [],
 		allowedMentions: {


### PR DESCRIPTION
# Why?

Mainly because Souji has OCD with message styles, jk lol (I have to admit I liked more the embed way)

# New Style

<details><summary>Old Style</summary>

![image](https://user-images.githubusercontent.com/67063134/219273690-730977fc-3f75-41f2-ace9-38a1f16a8152.png)
</details>

![image](https://user-images.githubusercontent.com/67063134/219273752-1a8c7aff-32f4-4ec2-977b-f788916e72bf.png)

