### PR TITLE
fix(metrics): use new URL API

### DIFF
--- a/apps/yuudachi/src/events/readyOnce.ts
+++ b/apps/yuudachi/src/events/readyOnce.ts
@@ -49,7 +49,7 @@ export default class implements Event {
 		);
 
 		const server = createServer(async (req, res) => {
-			const route = new URL(req.url!).pathname;
+			const route = new URL(req.url!, "http://noop").pathname;
 
 			if (route === "/metrics") {
 				logger.info({ event: { name: this.name, event: this.event } }, "Scraping /metrics request");


### PR DESCRIPTION
- `"http://noop"` is used, because we do not care about the base name when parsing for the route.
- this is used over `req.headers.host` as it resolves with `"localhost"` in local testing, and hardcoding a `"http"` prefix would be about as gross as this approach, but this one makes it clear why it is used.