### PR TITLE
chore(reports): adapt discord report link

### DIFF
--- a/apps/yuudachi/src/Constants.ts
+++ b/apps/yuudachi/src/Constants.ts
@@ -56,8 +56,3 @@ export const AUTOCOMPLETE_CASE_FOCUSED_FIELD_NAMES = ["case_reference", "referen
 export const AUTOCOMPLETE_REPORT_FOCUSED_FIELD_NAMES = ["report_reference", "reference_report", "report"];
 
 export const DISCORD_HOWTOREPORT = "https://discord.com/safety/360044103651-reporting-abusive-behavior-to-discord";
-
-export const DiscordLocales: { [key: string]: string } = {
-	"es-ES": "es",
-	"zh-CN": "zh-tw",
-};

--- a/apps/yuudachi/src/Constants.ts
+++ b/apps/yuudachi/src/Constants.ts
@@ -55,7 +55,7 @@ export const AUTOCOMPLETE_REASON_FOCUSED_FIELD_NAME = "reason";
 export const AUTOCOMPLETE_CASE_FOCUSED_FIELD_NAMES = ["case_reference", "reference_case", "case", "last_case"];
 export const AUTOCOMPLETE_REPORT_FOCUSED_FIELD_NAMES = ["report_reference", "reference_report", "report"];
 
-export const TRUST_AND_SAFETY_URL_BASE = "https://support.discord.com/hc/en-us/requests/new";
+export const DISCORD_HOWTOREPORT = "https://discord.com/safety/360044103651-reporting-abusive-behavior-to-discord";
 
 export const DiscordLocales: { [key: string]: string } = {
 	"es-ES": "es",

--- a/apps/yuudachi/src/commands/moderation/sub/report/message.ts
+++ b/apps/yuudachi/src/commands/moderation/sub/report/message.ts
@@ -5,6 +5,7 @@ import i18next from "i18next";
 import type { Redis } from "ioredis";
 import { nanoid } from "nanoid";
 import {
+	DISCORD_HOWTOREPORT,
 	REPORT_DUPLICATE_EXPIRE_SECONDS,
 	REPORT_DUPLICATE_PRE_EXPIRE_SECONDS,
 	REPORT_MESSAGE_CONTEXT_LIMIT,
@@ -17,7 +18,6 @@ import { type Report, createReport, ReportType } from "../../../../functions/rep
 import { getPendingReportByTarget } from "../../../../functions/reports/getReport.js";
 import type { ReportCommand } from "../../../../interactions/index.js";
 import { createMessageLinkButton } from "../../../../util/createMessageLinkButton.js";
-import { localeTrustAndSafety } from "../../../../util/localizeTrustAndSafety.js";
 
 type MessageReportArgs = Omit<ArgsParam<typeof ReportCommand>["message"], "message_link"> & {
 	message: Message;
@@ -50,7 +50,7 @@ export async function message(
 	});
 	const trustAndSafetyButton = createButton({
 		label: i18next.t("command.mod.report.common.buttons.discord_report", { lng: locale }),
-		url: localeTrustAndSafety(locale),
+		url: DISCORD_HOWTOREPORT,
 		style: ButtonStyle.Link,
 	});
 
@@ -64,7 +64,7 @@ export async function message(
 		i18next.t("command.mod.report.common.warnings", {
 			trust_and_safety: hyperlink(
 				i18next.t("command.mod.report.common.trust_and_safety_sub", { lng: locale }),
-				localeTrustAndSafety(locale),
+				DISCORD_HOWTOREPORT,
 			),
 			lng: locale,
 		}),

--- a/apps/yuudachi/src/commands/moderation/sub/report/user.ts
+++ b/apps/yuudachi/src/commands/moderation/sub/report/user.ts
@@ -16,6 +16,7 @@ import {
 	REPORT_REASON_MAX_LENGTH,
 	REPORT_DUPLICATE_EXPIRE_SECONDS,
 	REPORT_DUPLICATE_PRE_EXPIRE_SECONDS,
+	DISCORD_HOWTOREPORT,
 } from "../../../../Constants.js";
 import { forwardReport } from "../../../../functions/logging/forwardReport.js";
 import { upsertReportLog } from "../../../../functions/logging/upsertReportLog.js";
@@ -23,7 +24,6 @@ import { type Report, createReport, ReportType } from "../../../../functions/rep
 import { updateReport } from "../../../../functions/reports/updateReport.js";
 import type { ReportCommand } from "../../../../interactions/index.js";
 import { resolveGuildCommand, chatInputApplicationCommandMention } from "../../../../util/commandUtils.js";
-import { localeTrustAndSafety } from "../../../../util/localizeTrustAndSafety.js";
 
 type MemberAssuredReportArgs = ArgsParam<typeof ReportCommand>["user"] & { user: { member: GuildMember } };
 
@@ -68,7 +68,7 @@ export async function user(
 	});
 	const trustAndSafetyButton = createButton({
 		label: i18next.t("command.mod.report.common.buttons.discord_report", { lng: locale }),
-		url: localeTrustAndSafety(locale),
+		url: DISCORD_HOWTOREPORT,
 		style: ButtonStyle.Link,
 	});
 
@@ -102,7 +102,7 @@ export async function user(
 		i18next.t("command.mod.report.common.warnings", {
 			trust_and_safety: hyperlink(
 				i18next.t("command.mod.report.common.trust_and_safety_sub", { lng: locale }),
-				localeTrustAndSafety(locale),
+				DISCORD_HOWTOREPORT,
 			),
 			lng: locale,
 		}),

--- a/apps/yuudachi/src/util/localizeTrustAndSafety.ts
+++ b/apps/yuudachi/src/util/localizeTrustAndSafety.ts
@@ -1,5 +1,0 @@
-import { DiscordLocales, TRUST_AND_SAFETY_URL_BASE } from "../Constants.js";
-
-export function localeTrustAndSafety(locale: string): string {
-	return TRUST_AND_SAFETY_URL_BASE.replace("en-us", DiscordLocales[locale] ?? locale.toLowerCase());
-}


### PR DESCRIPTION
* link to helpdesk article instead of support form (no longer used for reports)
* remove localization of support form, as it is no longer needed

resolves #1191